### PR TITLE
Add CLAUDE.md developer reference guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,8 @@ src/
     test-runs/       # Test run UI components
   pages/
     app/             # Protected routes (require auth): Dashboard, Library, Builder, Tests, Billing, Admin
-    *.tsx            # Public routes: Landing, Pricing, Learn, Library, Auth
+    *.tsx            # Public routes: Landing, Pricing, Learn, Library
+                     # Auth page (/auth) — unauthenticated access, not listed in README public routes
   hooks/             # Custom hooks (useAuth, useSubscription, useTestRuns, etc.)
   lib/               # Utilities (utils.ts, stripe.ts)
   integrations/
@@ -59,14 +60,16 @@ supabase/
 
 ## TypeScript Config Notes
 
-- `strictNullChecks: false` — null checks are not enforced
-- `noImplicitAny: false` — implicit `any` is allowed (not ideal, but current state)
-- `@typescript-eslint/no-unused-vars: off` — unused vars do not trigger lint errors
+> **Technical debt:** The settings below contradict the README's principle of "TypeScript strict; avoid `any`." New code should use explicit types and handle `null`/`undefined` properly even though the compiler does not enforce it yet. Enabling stricter checks is a planned follow-up.
+
+- `strictNullChecks: false` — null checks are not enforced (treat as temporary; write null-safe code anyway)
+- `noImplicitAny: false` — implicit `any` is allowed (avoid `any` in new code; prefer explicit types)
+- `@typescript-eslint/no-unused-vars: off` — unused vars do not trigger lint errors (clean up dead code when you touch a file)
 
 ## Architecture Rules
 
 - **Multi-tenancy:** Every read/write scoped by `workspace_id` (except global learn content). Never trust client-provided `workspace_id`.
-- **Routes:** Public (`/`, `/pricing`, `/learn`, `/library`, `/p/:slug`) vs Protected (`/app/*` — server-side session checks)
+- **Routes:** Public (`/`, `/pricing`, `/learn`, `/library`, `/p/:slug`) + Auth (`/auth`) vs Protected (`/app/*` — server-side session checks)
 - **Roles:** viewer (read-only) → member (create/edit own) → admin/owner (manage workspace) → site admin (`/app/admin`)
 - **Seed data:** Must be idempotent — use upserts/unique constraints, never create duplicates
 


### PR DESCRIPTION
## Summary
Add a comprehensive developer reference guide (`CLAUDE.md`) to help developers quickly understand the project structure, tech stack, conventions, and workflows.

## Changes
- **New file:** `CLAUDE.md` with quick reference commands, tech stack overview, and project structure
- Documents the complete directory layout with descriptions of each folder's purpose
- Includes key conventions for naming, imports, components, data fetching, and styling
- Outlines TypeScript configuration notes and architecture rules (multi-tenancy, roles, routes)
- Provides testing framework details and CI pipeline requirements
- Establishes change policy guidelines for incremental development

## Details
This guide serves as a living reference for developers working on the project, covering:
- **Quick commands** for common development tasks (dev, build, lint, test)
- **Tech stack** overview (React 18, TypeScript, Vite, shadcn/ui, TanStack Query, Supabase, Stripe)
- **Path aliases** and import conventions using `@/` prefix
- **Multi-tenancy architecture** with workspace scoping and role-based access
- **Testing approach** with Vitest and co-located test files
- **CI/CD pipeline** requirements (lint, typecheck, test, audit, build)

This complements the existing `README.md` and provides a quick reference for developers to maintain consistency across the codebase.

https://claude.ai/code/session_01Xk1gyMkSAeFifxMHtbX8dB