### PR TITLE
docs: add /auth to public routes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ Build a premium, trustworthy SaaS for prompt-engineering workflows. Prioritise c
 
 ## Architecture conventions
 ### Routes
-- Public: `/`, `/pricing`, `/learn`, `/learn/{slug}`, `/library`, `/p/{slug}`
+- Public: `/`, `/pricing`, `/learn`, `/learn/{slug}`, `/library`, `/p/{slug}`, `/auth`
 - App (auth required): `/app/*`
+
+> **Note:** `/auth` is a standalone public page (outside the marketing layout) that handles
+> sign-in and sign-up (`/auth?mode=signup`). Authenticated users are automatically
+> redirected to `/app/dashboard`.
 
 ### App shell
 - Under `/app`: left sidebar with workspace switcher + primary navigation.


### PR DESCRIPTION
The /auth route was present in App.tsx as a standalone public page
but missing from the documented public routes list. Added it to
the routes section with a note explaining its behavior (login/signup,
redirect when authenticated).

https://claude.ai/code/session_01HYPs9H4k59HTGCVTpu4GUZ