### PR TITLE
Update Copilot/Codex guide with CI docs-only optimization and security best practices

### DIFF
--- a/docs/trading-bot-swarm-copilot-codex-guide.md
+++ b/docs/trading-bot-swarm-copilot-codex-guide.md
@@ -96,16 +96,12 @@ assistant:
 ```yaml
 name: quality-gate
 on:
-  push:
+  push: &trigger_config
     branches: [main]
     paths-ignore:
       - "**/*.md"
       - "docs/**"
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
+  pull_request: *trigger_config
 
 jobs:
   quality-gate:

--- a/docs/trading-bot-swarm-copilot-codex-guide.md
+++ b/docs/trading-bot-swarm-copilot-codex-guide.md
@@ -8,6 +8,7 @@ This guide defines how to configure GitHub Copilot and Codex in the Trading Bot 
 - **Mandatory for code changes**: run unit tests and linting for any change that affects runtime behavior.
 - **Documentation-only changes**: skip tests and linting unless the docs reference code that must be validated.
 - **Local-first validation**: validate in local/dev environments before pushing.
+- **Workflow optimization**: use CI `paths-ignore` or change detection to avoid unnecessary jobs on docs-only updates.
 
 ### Code style
 - Enforce consistent formatting via Prettier/ESLint (or equivalent for each language).
@@ -33,11 +34,13 @@ This guide defines how to configure GitHub Copilot and Codex in the Trading Bot 
 - Define quality gates: lint, unit tests, security scans, and type checks.
 - Block merges on quality gate failures.
 - Maintain a consistent build pipeline across repositories.
+- Keep CI secrets scoped to least privilege and rotate on a fixed cadence.
 
 ### Version control
 - Use conventional commits and semantic versioning.
 - Require PR review and automated checks before merge.
 - Tag releases via CI for traceability.
+- Prefer protected branches, signed commits, and linear history where possible.
 
 ## Custom instruction behavior for Codex and Copilot
 ### Example rules
@@ -80,6 +83,7 @@ assistant:
 **Trigger conditions**
 - Run on pull requests targeting `main`.
 - Run on pushes to `main`.
+- Skip the workflow when only documentation changes are present (optional but recommended).
 
 **Quality gate steps**
 - Checkout repository
@@ -94,8 +98,14 @@ name: quality-gate
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
 
 jobs:
   quality-gate:


### PR DESCRIPTION
### Motivation
- Improve the Copilot/Codex configuration guide to reduce unnecessary CI runs for documentation-only changes and reinforce CI security and branch-protection best practices in the Trading Bot Swarm guide.

### Description
- Edited `docs/trading-bot-swarm-copilot-codex-guide.md` to add a `paths-ignore` example for the `quality-gate` workflow that skips CI on `**/*.md` and `docs/**` changes and to recommend `paths-ignore`/change-detection for docs-only updates, CI secret rotation, and protected-branch/signed-commit practices.

### Testing
- Automated tests were not run because this is a documentation-only change and the update only adjusts guidance and example YAML in `docs/trading-bot-swarm-copilot-codex-guide.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69899e9e61208332ac95a965431f7aad)