### PR TITLE
Align Vitest config with `client/src` architecture

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,10 +7,14 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
-    setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    setupFiles: ["./client/src/test/setup.ts"],
+    include: ["client/src/**/*.{test,spec}.{ts,tsx}"],
   },
   resolve: {
-    alias: { "@": path.resolve(__dirname, "./src") },
+    alias: {
+      "@": path.resolve(__dirname, "client", "src"),
+      "@shared": path.resolve(__dirname, "shared"),
+      "@assets": path.resolve(__dirname, "attached_assets"),
+    },
   },
 });


### PR DESCRIPTION
### Motivation
- The project was refactored to place application sources under `client/src`, but `vitest.config.ts` still referenced the old `./src` layout and a different alias mapping, which prevents test setup files and module aliases from resolving correctly.

### Description
- Updated `setupFiles` to `./client/src/test/setup.ts` so Vitest loads the correct test initialization file.
- Changed the test discovery glob to `client/src/**/*.{test,spec}.{ts,tsx}` so tests under the new source tree are picked up.
- Aligned `resolve.alias` with the Vite config by pointing `@` to `client/src` and adding `@shared` and `@assets` aliases.

### Testing
- Ran `npm run test -- --run` and all suites passed successfully (3 test files, 24 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ed4f5983c83328efc6fa622a27d02)