### PR TITLE
Add two-way GitHub ↔ Hugging Face Hub sync workflow

### DIFF
--- a/.github/workflows/huggingface-sync.yml
+++ b/.github/workflows/huggingface-sync.yml
@@ -1,0 +1,92 @@
+name: Two-Way Sync: GitHub ↔ Hugging Face Hub
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      sync_direction:
+        description: "Choose sync direction"
+        required: true
+        default: "github-to-huggingface"
+        type: choice
+        options:
+          - github-to-huggingface
+          - huggingface-to-github
+
+permissions:
+  contents: write
+
+concurrency:
+  group: repo-sync-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sync-github-to-huggingface:
+    name: Sync GitHub to Hugging Face
+    if: github.event_name == 'push' || github.event.inputs.sync_direction == 'github-to-huggingface'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout GitHub repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add Hugging Face remote
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_USERNAME: ${{ secrets.HF_USERNAME }}
+        run: |
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          git remote remove huggingface 2>/dev/null || true
+          git remote add huggingface "https://${HF_USERNAME}:${HF_TOKEN}@huggingface.co/spaces/${HF_USERNAME}/${REPO_NAME}"
+
+      - name: Push to Hugging Face Hub
+        run: |
+          git push huggingface main:main --force-with-lease
+
+  sync-huggingface-to-github:
+    name: Sync Hugging Face to GitHub
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.sync_direction == 'huggingface-to-github'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout GitHub repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Configure Git identity
+        run: |
+          git config --global user.name "repo-sync-bot"
+          git config --global user.email "repo-sync-bot@users.noreply.github.com"
+
+      - name: Add Hugging Face remote
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_USERNAME: ${{ secrets.HF_USERNAME }}
+        run: |
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          git remote remove huggingface 2>/dev/null || true
+          git remote add huggingface "https://${HF_USERNAME}:${HF_TOKEN}@huggingface.co/spaces/${HF_USERNAME}/${REPO_NAME}"
+
+      - name: Fetch Hugging Face main
+        run: |
+          git fetch huggingface main
+
+      - name: Merge Hugging Face into GitHub
+        run: |
+          git checkout main
+          git merge huggingface/main --no-edit --allow-unrelated-histories
+
+      - name: Push merged state to GitHub
+        run: |
+          git push origin main

--- a/.github/workflows/huggingface-sync.yml
+++ b/.github/workflows/huggingface-sync.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Fetch Hugging Face remote
         run: |
-          git fetch huggingface main || true
+          git fetch huggingface main
 
       - name: Push to Hugging Face Hub
         run: |

--- a/.github/workflows/huggingface-sync.yml
+++ b/.github/workflows/huggingface-sync.yml
@@ -1,4 +1,4 @@
-name: Two-Way Sync: GitHub ↔ Hugging Face Hub
+name: "Two-Way Sync: GitHub ↔ Hugging Face Hub"
 
 on:
   push:
@@ -46,7 +46,13 @@ jobs:
         run: |
           REPO_NAME="${GITHUB_REPOSITORY#*/}"
           git remote remove huggingface 2>/dev/null || true
-          git remote add huggingface "https://${HF_USERNAME}:${HF_TOKEN}@huggingface.co/spaces/${HF_USERNAME}/${REPO_NAME}"
+          git remote add huggingface "https://huggingface.co/spaces/${HF_USERNAME}/${REPO_NAME}"
+          AUTH_HEADER="AUTHORIZATION: basic $(printf '%s:%s' "${HF_USERNAME}" "${HF_TOKEN}" | base64 -w0)"
+          git config --local "http.https://huggingface.co/.extraheader" "${AUTH_HEADER}"
+
+      - name: Fetch Hugging Face remote
+        run: |
+          git fetch huggingface main || true
 
       - name: Push to Hugging Face Hub
         run: |
@@ -76,7 +82,9 @@ jobs:
         run: |
           REPO_NAME="${GITHUB_REPOSITORY#*/}"
           git remote remove huggingface 2>/dev/null || true
-          git remote add huggingface "https://${HF_USERNAME}:${HF_TOKEN}@huggingface.co/spaces/${HF_USERNAME}/${REPO_NAME}"
+          git remote add huggingface "https://huggingface.co/spaces/${HF_USERNAME}/${REPO_NAME}"
+          AUTH_HEADER="AUTHORIZATION: basic $(printf '%s:%s' "${HF_USERNAME}" "${HF_TOKEN}" | base64 -w0)"
+          git config --local "http.https://huggingface.co/.extraheader" "${AUTH_HEADER}"
 
       - name: Fetch Hugging Face main
         run: |
@@ -85,7 +93,11 @@ jobs:
       - name: Merge Hugging Face into GitHub
         run: |
           git checkout main
-          git merge huggingface/main --no-edit --allow-unrelated-histories
+          if ! git merge huggingface/main --no-edit; then
+            echo "::error::Merge conflict between Hugging Face main and GitHub main — resolve manually and re-run."
+            git merge --abort || true
+            exit 1
+          fi
 
       - name: Push merged state to GitHub
         run: |


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/huggingface-sync.yml` for two-way sync between GitHub and Hugging Face Hub
- On every push to `main`, the repo is automatically mirrored to the matching Hugging Face Space
- Manual `workflow_dispatch` allows pulling changes from Hugging Face back into GitHub via merge

## Required Secrets

Before enabling, add these repository secrets:

| Secret | Purpose |
|---|---|
| `HF_TOKEN` | Hugging Face API token with write access |
| `HF_USERNAME` | Hugging Face username (used to construct the Space URL) |
| `GH_PAT` | GitHub Personal Access Token with `contents: write` (needed for the HF→GH direction only) |

## Test plan

- [ ] Add the three required secrets to the repository
- [ ] Push a commit to `main` and verify the workflow triggers and pushes to Hugging Face
- [ ] Manually trigger with `huggingface-to-github` direction and verify merge succeeds
- [ ] Confirm concurrency group prevents overlapping sync runs

https://claude.ai/code/session_01NvjKvYdKRzDvRehTg1m14n

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvjKvYdKRzDvRehTg1m14n)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated bidirectional synchronization between the GitHub repository and Hugging Face Spaces. The system automatically syncs changes when pushed to the main branch and provides manual trigger capabilities with flexible configuration options for cross-platform repository management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canstralian/prompt-crafting/pull/80)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->