### PR TITLE
docs: align Cloudflare Pages recommendation with npm-only lockfile

### DIFF
--- a/docs/trading-bot-swarm-copilot-codex-guide.md
+++ b/docs/trading-bot-swarm-copilot-codex-guide.md
@@ -329,7 +329,8 @@ Use this for static SPA/SSR build output hosted on Cloudflare Pages.
 
 Recommended Pages settings:
 
-- Build command: `bun run build` (or `npm run build`)
+- Build command: `npm run build`
+- Install command: `npm ci`
 - Output directory: `dist`
 
 ### Common failure pattern and fix


### PR DESCRIPTION
## Summary

The repo is already on an npm-only lockfile — `package-lock.json` is committed, `bun.lockb` is absent, and no `bunfig.toml` / `bun.config.*` exist. The only outstanding Bun reference was in `docs/trading-bot-swarm-copilot-codex-guide.md`, which recommended `bun run build` as the primary Cloudflare Pages build command.

This PR updates that recommendation:
- Drops `bun run build` from the recommended Pages settings.
- Adds an explicit `npm ci` install command so Cloudflare's builder does not auto-detect Bun from any residual environment signal.

## Repo audit (no change required)

| Check | Result |
|---|---|
| `bun.lockb` tracked or in tree | None |
| `bunfig.toml` / `bun.config.*` | None |
| `package.json` references to bun | None |
| `.github/workflows/*` references to bun | None (only `ubuntu-latest` matched) |
| `package-lock.json` present | Yes (committed) |

## Follow-up (out of repo)

In the Cloudflare Pages project settings, set:
- **Install command:** `npm ci`
- **Build command:** `npm run build`
- **Output directory:** `dist`

Leaving the install command blank lets Cloudflare auto-detect — and once a project has been built with Bun, the auto-detector can keep selecting it. An explicit `npm ci` removes that ambiguity.

## Test plan

- [ ] Cloudflare Pages preview build on this PR uses `npm ci` (verify in build logs)
- [ ] Build proceeds past the install step

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgJjuJH2s6pxaTRCy7WE5J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Cloudflare Pages deployment instructions to use npm commands for the build and dependency installation steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canstralian/prompt-crafting/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->