### PR TITLE
fix(build): revert Tailwind to v3 to match existing CSS and config

### DIFF
--- a/docs/trading-bot-swarm-copilot-codex-guide.md
+++ b/docs/trading-bot-swarm-copilot-codex-guide.md
@@ -331,6 +331,7 @@ Recommended Pages settings:
 
 - Build command: `npm run build`
 - Install command: `npm ci`
+- Environment variable: `NODE_VERSION=20`
 - Output directory: `dist`
 
 ### Common failure pattern and fix

--- a/docs/trading-bot-swarm-copilot-codex-guide.md
+++ b/docs/trading-bot-swarm-copilot-codex-guide.md
@@ -329,7 +329,8 @@ Use this for static SPA/SSR build output hosted on Cloudflare Pages.
 
 Recommended Pages settings:
 
-- Build command: `bun run build` (or `npm run build`)
+- Build command: `npm run build`
+- Install command: `npm ci`
 - Output directory: `dist`
 
 ### Common failure pattern and fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
         "globals": "^15.15.0",
         "jsdom": "^20.0.3",
         "postcss": "^8.5.6",
-        "tailwindcss": "^4.1.18",
+        "tailwindcss": "^3.4.17",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.38.0",
         "vite": "^7.3.1",
@@ -8852,43 +8852,6 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
-    "node_modules/lovable-tagger/node_modules/tailwindcss": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
-      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "arg": "^5.0.2",
-        "chokidar": "^3.6.0",
-        "didyoumean": "^1.2.2",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.3.2",
-        "glob-parent": "^6.0.2",
-        "is-glob": "^4.0.3",
-        "jiti": "^1.21.7",
-        "lilconfig": "^3.1.3",
-        "micromatch": "^4.0.8",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^3.0.0",
-        "picocolors": "^1.1.1",
-        "postcss": "^8.4.47",
-        "postcss-import": "^15.1.0",
-        "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
-        "postcss-nested": "^6.2.0",
-        "postcss-selector-parser": "^6.1.2",
-        "resolve": "^1.22.8",
-        "sucrase": "^3.35.0"
-      },
-      "bin": {
-        "tailwind": "lib/cli.js",
-        "tailwindcss": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/lucide-react": {
       "version": "0.462.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.462.0.tgz",
@@ -10804,10 +10767,41 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
-      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT"
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "globals": "^15.15.0",
     "jsdom": "^20.0.3",
     "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.18",
+    "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
     "vite": "^7.3.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
 export default {
   plugins: {
-    "@tailwindcss/postcss": {},
+    tailwindcss: {},
+    autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary

The repo is in a half-finished Tailwind v3 → v4 migration that breaks the frontend build. This PR reverts to v3 — the lowest-risk path to a green build, since every layer **except** the package.json pin and the PostCSS plugin choice is already v3-shaped.

## The mismatch

| Layer | State on main | Notes |
|---|---|---|
| `package.json` | v4 (`tailwindcss: ^4.1.18`) | Bumped without finishing the migration |
| `postcss.config.js` | v4 plugin (`@tailwindcss/postcss`) | Plugin was **never added** to dependencies |
| `client/src/index.css` | v3 directives (`@tailwind base/components/utilities;`) | Invalid in v4 (v4 uses `@import "tailwindcss";`) |
| `tailwind.config.ts` | v3-shape JS config + `tailwindcss-animate` (v3-only) | v4 doesn't auto-load JS configs |

Cloudflare Pages build log confirms the exact failure (commit `e2aaf89`, PR #92, which doesn't yet include this fix):

```
[vite:css] Failed to load PostCSS config (searchPath: /opt/buildhome/repo/client):
[Error] Loading PostCSS Plugin failed: Cannot find module '@tailwindcss/postcss'
Require stack:
- /opt/buildhome/repo/postcss.config.js
```

## Changes

- `package.json`: `tailwindcss ^4.1.18` → `^3.4.17`
- `postcss.config.js`: `{ "@tailwindcss/postcss": {} }` → `{ tailwindcss: {}, autoprefixer: {} }`
- `package-lock.json` regenerated by `npm install` to match
- `docs/trading-bot-swarm-copilot-codex-guide.md`: `bun run build` → `npm ci` / `npm run build`; add `NODE_VERSION=20` to the recommended Cloudflare Pages env vars (per gemini-code-assist review feedback)

## Verification

Local `npm run build` is green:

```
vite v7.3.1 building client environment for production...
✓ 2498 modules transformed.
dist/public/index.html                   2.02 kB │ gzip:   0.63 kB
dist/public/assets/index-DVnyOhu2.css   81.84 kB │ gzip:  13.77 kB
dist/public/assets/index-BHJnimek.js   776.85 kB │ gzip: 238.36 kB
✓ built in 7.39s
dist/index.mjs  27.8kb
```

## What this PR is and isn't

- **Fixes** the Cloudflare Pages build (the `[vite:css] Failed to load PostCSS config` error). Pages already invokes `npm clean-install` and `npm run build`; no dashboard changes are required for the Pages check to go green.
- **Does not fix** the two **Workers Builds** integrations (`prompt-crafting`, `builder-prompt-engine`) that have been failing **instantly** on every PR. Those integrations target a Worker `main` entrypoint, but the repo's `wrangler.toml` is Pages-shape (`pages_build_output_dir = "dist"`, no `main`). They will keep failing until either (a) those Workers Builds integrations are removed in the Cloudflare dashboard, or (b) a Worker `main` is added to `wrangler.toml`. Out of scope for this PR.

## If v4 is desired long-term

A v4 migration is a separate, larger effort: rewrite `index.css` to `@import "tailwindcss";`, port `tailwind.config.ts` theme into a CSS `@theme` block, replace `tailwindcss-animate` with a v4-compatible alternative (e.g. `tw-animate-css`), and verify each shadcn component still renders. Out of scope for this fix.

## Test plan

- [ ] Cloudflare Pages build on this PR completes successfully (this is the meaningful signal)
- [ ] No visual regressions in the rendered app (Tailwind v3 produces same output as before the half-migration)
- [ ] Workers Builds checks remain failing (separate, pre-existing config issue — see "What this PR is and isn't")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Cloudflare Pages deployment documentation to specify Node.js version 20 and npm-based build tooling.

* **Chores**
  * Updated CSS framework dependency version.
  * Updated PostCSS styling plugin configuration to align with dependency changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canstralian/prompt-crafting/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->