### PR TITLE
feat: add spec-drift-hunter and reviewer-load-balancer skills

### DIFF
--- a/.agents/skills/reviewer-load-balancer/SKILL.md
+++ b/.agents/skills/reviewer-load-balancer/SKILL.md
@@ -21,7 +21,7 @@ For a single PR, all three can run inline.
 
 - `mcp__github__pull_request_read`, `mcp__github__get_file_contents`, `mcp__github__list_branches` for diff inspection.
 - `Bash` + `git diff --name-only` when running locally.
-- `mcp__github__add_issue_comment` ONLY when the dispatcher stage needs to ping CodeRabbit / Gemini (those reviewers are typically invoked via PR comment). Never post commentary from the planner stages.
+- `mcp__github__add_issue_comment` is dispatcher-only. The dispatcher stage may use it to ping CodeRabbit / Gemini (typically invoked via PR comment) and to request explicit human-reviewer assignment when none is specified. Planner stages (`file-classifier`, `reviewer-router`) must never post commentary.
 
 ## Stop conditions
 

--- a/.agents/skills/reviewer-load-balancer/SKILL.md
+++ b/.agents/skills/reviewer-load-balancer/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: reviewer-load-balancer
+description: Decide which code reviewers (CodeRabbit, Gemini, Semgrep, CodeQL, Claude/Codex agents, human) should run on a PR, in what order, and on which files — so cheap PRs get cheap reviews and expensive reviewers are reserved for changes that warrant them. Output: a routing plan listing each reviewer to invoke, the file globs they should look at, the order, the skip rationale for reviewers that were excluded, and an estimated cost class.
+---
+
+# Reviewer Load Balancer (agent edition)
+
+Agent-facing variant. Full spec lives at `.claude/skills/reviewer-load-balancer/SKILL.md` — read it first.
+
+## Delegation
+
+For a single PR you can run the loop inline. For backlog sweeps (10+ PRs), delegate:
+
+- `agents/file-classifier.md` — bucket every changed file into one class from the routing table.
+- `agents/reviewer-router.md` — apply the routing rules to the classifications and emit the per-PR plan.
+- `agents/review-dispatcher.md` — turn the plan into concrete invocations (workflow_dispatch payload, CodeRabbit `@coderabbitai review` comment, `mcp__github__pull_request_review_write` for Claude, human-reviewer assignment).
+
+For a single PR, all three can run inline.
+
+## Tool budget
+
+- `mcp__github__pull_request_read`, `mcp__github__get_file_contents`, `mcp__github__list_branches` for diff inspection.
+- `Bash` + `git diff --name-only` when running locally.
+- `mcp__github__add_issue_comment` ONLY when the dispatcher stage needs to ping CodeRabbit / Gemini (those reviewers are typically invoked via PR comment). Never post commentary from the planner stages.
+
+## Stop conditions
+
+- Every changed file has exactly one classification.
+- Every reviewer in the roster is either scheduled or has a one-line skip reason.
+- Plan rendered in the format specified in the main SKILL.md.
+- Cost class assigned.
+
+## Coordination with sibling skills
+
+- If `workflow/CI` files are touched, the plan MUST include `spec-drift-hunter` (workflow claims drift constantly).
+- If the PR is doc-only and tiny, this skill's plan is the entire review — no further skills needed.
+- If the plan ends up `BLOCKED-ON-HUMAN`, mark the PR as draft and assign a human reviewer; do not auto-merge.

--- a/.agents/skills/reviewer-load-balancer/agents/file-classifier.md
+++ b/.agents/skills/reviewer-load-balancer/agents/file-classifier.md
@@ -16,6 +16,8 @@ tools: Read, Bash, mcp__github__pull_request_read, mcp__github__get_file_content
    docs-only, workflow / CI, infra / IaC, runtime Python, runtime TS/JS, tests, shared contracts, lockfiles, generated / vendored, binary / unsupported, secrets-adjacent.
 3. Use glob precedence — earlier classes in the routing table win for ambiguous files. Specifically: `secrets-adjacent` and `generated/vendored` always override their containing directory's natural class.
 4. For each file also record: bytes changed, whether the file is new/deleted/renamed, and whether it sits in a security-sensitive directory (`server/middleware*`, `auth*`, `session*`).
+5. For files classified as `shared contracts`, also emit a `breaking_api_change_signal` boolean. Set it to `true` when the diff shows any of: a removed or renamed exported symbol, a removed enum value, a field/column dropped, a non-optional field added without a default, a route/endpoint removed, or a schema version bumped. Otherwise `false`. If the diff cannot be inspected (e.g., binary diff), set it to `true` and add a note — the router treats unknown as worst-case for contract files.
+6. Aggregate a top-level `breaking_api_change_signal` boolean: `true` if any file in step 5 reported `true`.
 
 ## Output
 ```json
@@ -24,10 +26,12 @@ tools: Read, Bash, mcp__github__pull_request_read, mcp__github__get_file_content
   "files": [
     { "path": "README.md", "class": "docs-only", "bytes_changed": 412, "status": "modified", "sensitive": false },
     { "path": ".env.example", "class": "secrets-adjacent", "bytes_changed": 8, "status": "modified", "sensitive": true },
+    { "path": "shared/schema.ts", "class": "shared contracts", "bytes_changed": 220, "status": "modified", "sensitive": false, "breaking_api_change_signal": true, "breaking_change_note": "exported `User.email` made non-optional without default" },
     ...
   ],
-  "classes_present": ["docs-only", "secrets-adjacent"],
-  "totals": { "files": 2, "lines_added": 14, "lines_removed": 3 }
+  "classes_present": ["docs-only", "secrets-adjacent", "shared contracts"],
+  "totals": { "files": 3, "lines_added": 24, "lines_removed": 3 },
+  "breaking_api_change_signal": true
 }
 ```
 

--- a/.agents/skills/reviewer-load-balancer/agents/file-classifier.md
+++ b/.agents/skills/reviewer-load-balancer/agents/file-classifier.md
@@ -13,7 +13,7 @@ tools: Read, Bash, mcp__github__pull_request_read, mcp__github__get_file_content
 ## What to do
 1. Get the list of changed files (`mcp__github__pull_request_read` for a PR; `git diff --name-only base...HEAD` for a local branch).
 2. For each file, assign exactly one class from this set:
-   `docs-only`, `workflow/CI`, `infra/IaC`, `runtime-python`, `runtime-ts-js`, `tests`, `shared-contracts`, `lockfiles`, `generated/vendored`, `binary/unsupported`, `secrets-adjacent`.
+   docs-only, workflow / CI, infra / IaC, runtime Python, runtime TS/JS, tests, shared contracts, lockfiles, generated / vendored, binary / unsupported, secrets-adjacent.
 3. Use glob precedence — earlier classes in the routing table win for ambiguous files. Specifically: `secrets-adjacent` and `generated/vendored` always override their containing directory's natural class.
 4. For each file also record: bytes changed, whether the file is new/deleted/renamed, and whether it sits in a security-sensitive directory (`server/middleware*`, `auth*`, `session*`).
 

--- a/.agents/skills/reviewer-load-balancer/agents/file-classifier.md
+++ b/.agents/skills/reviewer-load-balancer/agents/file-classifier.md
@@ -1,0 +1,37 @@
+---
+name: file-classifier
+description: Read-only agent that takes a list of changed files from a PR diff and assigns each file exactly one class from the reviewer-load-balancer routing table. First stage of the load-balancer loop.
+tools: Read, Bash, mcp__github__pull_request_read, mcp__github__get_file_contents
+---
+
+# file-classifier
+
+## Inputs
+- `pr`: PR number, OR
+- `paths`: explicit list of file paths
+
+## What to do
+1. Get the list of changed files (`mcp__github__pull_request_read` for a PR; `git diff --name-only base...HEAD` for a local branch).
+2. For each file, assign exactly one class from this set:
+   `docs-only`, `workflow/CI`, `infra/IaC`, `runtime-python`, `runtime-ts-js`, `tests`, `shared-contracts`, `lockfiles`, `generated/vendored`, `binary/unsupported`, `secrets-adjacent`.
+3. Use glob precedence — earlier classes in the routing table win for ambiguous files. Specifically: `secrets-adjacent` and `generated/vendored` always override their containing directory's natural class.
+4. For each file also record: bytes changed, whether the file is new/deleted/renamed, and whether it sits in a security-sensitive directory (`server/middleware*`, `auth*`, `session*`).
+
+## Output
+```json
+{
+  "pr": <number-or-null>,
+  "files": [
+    { "path": "README.md", "class": "docs-only", "bytes_changed": 412, "status": "modified", "sensitive": false },
+    { "path": ".env.example", "class": "secrets-adjacent", "bytes_changed": 8, "status": "modified", "sensitive": true },
+    ...
+  ],
+  "classes_present": ["docs-only", "secrets-adjacent"],
+  "totals": { "files": 2, "lines_added": 14, "lines_removed": 3 }
+}
+```
+
+## Constraints
+- Read-only.
+- One class per file. If two could apply, prefer the higher-risk class (security > workflow > code > docs > generated).
+- Do not invent files. If `mcp__github__pull_request_read` returns nothing, emit `{"files": [], ...}` and let the next stage handle the empty diff.

--- a/.agents/skills/reviewer-load-balancer/agents/review-dispatcher.md
+++ b/.agents/skills/reviewer-load-balancer/agents/review-dispatcher.md
@@ -15,7 +15,8 @@ For each step in `plan`, in order:
 
 | Reviewer | How to invoke |
 |---|---|
-| `semgrep` | If a `semgrep.yml` workflow exists, ensure it's triggered by `pull_request` and the PR has at least one commit; no manual action needed. Otherwise note `not wired`. |
+| audit | Run npm audit, cargo audit, or pip-audit via Bash depending on the lockfile type. |
+| semgrep | If a semgrep.yml workflow exists, ensure it's triggered by pull_request and the PR has at least one commit; no manual action needed. Otherwise note not wired. |
 | `codeql` | Same as Semgrep — confirm `codeql-analysis.yml` runs on PR. If not, do nothing and add to `skipped`. |
 | `coderabbit` | Post a comment on the PR: `@coderabbitai review`. Limit to files in the planned globs by mentioning them. |
 | `gemini` | Equivalent comment for the project's Gemini integration (e.g. `/gemini review`). If integration absent, skip. |

--- a/.agents/skills/reviewer-load-balancer/agents/review-dispatcher.md
+++ b/.agents/skills/reviewer-load-balancer/agents/review-dispatcher.md
@@ -1,0 +1,45 @@
+---
+name: review-dispatcher
+description: Agent that takes the reviewer-router's plan and issues the concrete invocations — PR comments for CodeRabbit/Gemini, `workflow_dispatch` for Semgrep/CodeQL, `pull_request_review_write` for Claude, reviewer assignment for humans. Stage three of the reviewer-load-balancer loop.
+tools: Bash, mcp__github__add_issue_comment, mcp__github__pull_request_read, mcp__github__pull_request_review_write, mcp__github__update_pull_request, mcp__github__get_file_contents
+---
+
+# review-dispatcher
+
+## Inputs
+- Plan emitted by `reviewer-router`.
+- PR number.
+
+## What to do
+For each step in `plan`, in order:
+
+| Reviewer | How to invoke |
+|---|---|
+| `semgrep` | If a `semgrep.yml` workflow exists, ensure it's triggered by `pull_request` and the PR has at least one commit; no manual action needed. Otherwise note `not wired`. |
+| `codeql` | Same as Semgrep — confirm `codeql-analysis.yml` runs on PR. If not, do nothing and add to `skipped`. |
+| `coderabbit` | Post a comment on the PR: `@coderabbitai review`. Limit to files in the planned globs by mentioning them. |
+| `gemini` | Equivalent comment for the project's Gemini integration (e.g. `/gemini review`). If integration absent, skip. |
+| `claude` | Invoke the named skill (`spec-drift-hunter` for workflow drift, `/review` for general review) via `mcp__github__pull_request_review_write` or via a comment that triggers the project's Claude bot. |
+| `human` | Use `mcp__github__update_pull_request` to assign the appropriate human reviewer and convert the PR to draft if `cost_class: BLOCKED-ON-HUMAN`. If the user has not specified a human, leave a comment requesting assignment and do not guess. |
+
+## Output
+A short structured report:
+
+```json
+{
+  "pr": <number>,
+  "invocations": [
+    { "step": 1, "reviewer": "semgrep", "action": "auto-triggered on push", "status": "ok" },
+    { "step": 2, "reviewer": "coderabbit", "action": "posted '@coderabbitai review' comment", "status": "ok" },
+    { "step": 3, "reviewer": "human", "action": "awaiting assignment", "status": "pending", "note": "set PR to draft" }
+  ],
+  "skipped_confirmed": ["gemini", "codeql"]
+}
+```
+
+## Constraints
+- This is the ONLY stage allowed to post comments or change PR state.
+- Be frugal with comments. One invocation comment per reviewer per push — no spam.
+- If the plan is empty (e.g. SKIP for binary-only PR), do nothing and report `invocations: []`.
+- Never auto-merge. The dispatcher's job ends when reviewers have been invited.
+- If a human is required and `cost_class: BLOCKED-ON-HUMAN`, ensure the PR is marked draft so it cannot be auto-merged by another automation.

--- a/.agents/skills/reviewer-load-balancer/agents/reviewer-router.md
+++ b/.agents/skills/reviewer-load-balancer/agents/reviewer-router.md
@@ -23,7 +23,14 @@ tools: Read, Bash, mcp__github__get_file_contents
    8. Order rule (cheap-and-fast first)
 3. Mark reviewers that aren't wired into this repo as `n/a` rather than scheduling them.
 4. Compute file-glob assignments per reviewer — third-party reviewers (CodeRabbit, Gemini) MUST NOT receive secrets-adjacent files. Use explicit file lists or negative globs (e.g., !**/*secrets*) to enforce this.
-5. Assign cost class: `MINIMAL` (≤1 cheap reviewer), `LIGHT` (Claude lightweight only), `STANDARD` (2-3 reviewers, no human), `DEEP` (security/workflow involved or human added), `BLOCKED-ON-HUMAN` (secret-adjacent or breaking-API change).
+5. Assign cost class. The mapping is total and ordered — first match wins:
+   - `BLOCKED-ON-HUMAN` — any `secrets-adjacent` file present, OR `breaking_api_change_signal: true` from the classifier, OR `shared contracts` touched with a deletion/rename of an exported symbol.
+   - `DEEP` — any security/auth/workflow rule fired, OR a human reviewer is in the plan, OR the plan has 4 or more reviewers (regardless of why).
+   - `STANDARD` — 2 or 3 reviewers, no human, no security/workflow rule fired.
+   - `LIGHT` — exactly 1 reviewer and that reviewer is Claude in lightweight mode (tiny-diff rule fired).
+   - `MINIMAL` — 0 or 1 cheap reviewer (`semgrep`-only, `audit`-only, or empty plan).
+
+   If the classifier omits `breaking_api_change_signal` entirely, default it to `false` but flag the omission in the router's `notes` so the dispatcher can decide whether to escalate.
 
 ## Output
 ```json

--- a/.agents/skills/reviewer-load-balancer/agents/reviewer-router.md
+++ b/.agents/skills/reviewer-load-balancer/agents/reviewer-router.md
@@ -1,0 +1,49 @@
+---
+name: reviewer-router
+description: Read-only agent that takes a file classification (from file-classifier) and emits the per-PR review plan by applying the routing rules from the reviewer-load-balancer skill. Stage two of the load-balancer loop.
+tools: Read, Bash, mcp__github__get_file_contents
+---
+
+# reviewer-router
+
+## Inputs
+- Output of `file-classifier`.
+- Optional `repo_capabilities`: which reviewers are wired into this repo (e.g. `{"coderabbit": true, "gemini": false, "semgrep": true, "codeql": false}`). If absent, infer from `.github/workflows/` and `.coderabbit.yml`.
+
+## What to do
+1. For each file class present, look up the reviewer set from the routing table in `.claude/skills/reviewer-load-balancer/SKILL.md`.
+2. Apply the routing rules in order:
+   1. Skip rule
+   2. Secret rule
+   3. Tiny-diff rule
+   4. Workflow-gate rule (force-include `spec-drift-hunter` for Claude)
+   5. Auth/contract rule
+   6. Cost ceiling rule
+   7. Re-push rule (only relevant if `previous_run` is supplied; otherwise schedule all)
+   8. Order rule (cheap-and-fast first)
+3. Mark reviewers that aren't wired into this repo as `n/a` rather than scheduling them.
+4. Compute file-glob assignments per reviewer — third-party reviewers (CodeRabbit, Gemini) MUST NOT receive `secrets-adjacent` files even if other classes route them in.
+5. Assign cost class: `MINIMAL` (≤1 cheap reviewer), `LIGHT` (Claude lightweight only), `STANDARD` (2-3 reviewers, no human), `DEEP` (security/workflow involved or human added), `BLOCKED-ON-HUMAN` (secret-adjacent or breaking-API change).
+
+## Output
+```json
+{
+  "plan": [
+    { "step": 1, "reviewer": "semgrep", "globs": [".github/workflows/**"], "rationale": "workflow-gate rule", "cost": "low" },
+    { "step": 2, "reviewer": "claude", "skill": "spec-drift-hunter", "globs": [".github/workflows/**"], "rationale": "workflow-gate rule", "cost": "high" },
+    { "step": 3, "reviewer": "human", "globs": [".github/workflows/ci.yml"], "rationale": "required-check change", "cost": "very-high" }
+  ],
+  "skipped": [
+    { "reviewer": "coderabbit", "reason": "workflow YAML — Semgrep covers this surface more cheaply" },
+    { "reviewer": "gemini", "reason": "n/a — not wired into this repo" }
+  ],
+  "cost_class": "DEEP",
+  "triggered_rules": ["workflow-gate", "order"]
+}
+```
+
+## Constraints
+- Read-only.
+- Never invoke reviewers — only plan them. The dispatcher does the invocation.
+- Always emit `skipped` entries with reasons for completeness. A missing entry is worse than a redundant one.
+- If the file list is empty, emit `cost_class: MINIMAL` and `plan: []` with `triggered_rules: ["skip-rule"]`.

--- a/.agents/skills/reviewer-load-balancer/agents/reviewer-router.md
+++ b/.agents/skills/reviewer-load-balancer/agents/reviewer-router.md
@@ -22,7 +22,7 @@ tools: Read, Bash, mcp__github__get_file_contents
    7. Re-push rule (only relevant if `previous_run` is supplied; otherwise schedule all)
    8. Order rule (cheap-and-fast first)
 3. Mark reviewers that aren't wired into this repo as `n/a` rather than scheduling them.
-4. Compute file-glob assignments per reviewer — third-party reviewers (CodeRabbit, Gemini) MUST NOT receive `secrets-adjacent` files even if other classes route them in.
+4. Compute file-glob assignments per reviewer — third-party reviewers (CodeRabbit, Gemini) MUST NOT receive secrets-adjacent files. Use explicit file lists or negative globs (e.g., !**/*secrets*) to enforce this.
 5. Assign cost class: `MINIMAL` (≤1 cheap reviewer), `LIGHT` (Claude lightweight only), `STANDARD` (2-3 reviewers, no human), `DEEP` (security/workflow involved or human added), `BLOCKED-ON-HUMAN` (secret-adjacent or breaking-API change).
 
 ## Output

--- a/.agents/skills/spec-drift-hunter/SKILL.md
+++ b/.agents/skills/spec-drift-hunter/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: spec-drift-hunter
+description: Hunt architectural entropy by detecting divergence between what a repository CLAIMS (README, contracts, workflows, tests, issue intent, PR description) and what the code ACTUALLY does (implementation, configuration, CI gates, type coverage). Use when reviewing a PR, auditing a branch before release, triaging stale issues, or whenever you need to answer "do the docs/specs/tests still match the code?" Output: a structured drift report grouped by severity with file:line citations and a recommended remediation per finding.
+---
+
+# Spec Drift Hunter (agent edition)
+
+This is the agent-facing variant of the `spec-drift-hunter` skill. The full operating spec lives at `.claude/skills/spec-drift-hunter/SKILL.md` — read it first. The notes below cover how to run the loop from an autonomous agent context.
+
+## Delegation
+
+For non-trivial scope (multi-subsystem audit, full-repo sweep), delegate evidence collection in parallel:
+
+- `agents/claim-extractor.md` — pulls every assertion out of README, contracts, issue, PR body.
+- `agents/reality-prober.md` — verifies each claim against implementation, workflows, tests.
+- `agents/drift-reporter.md` — merges the two streams into a single severity-sorted report.
+
+For a single-PR review, you can run the loop inline without delegation.
+
+## Tool budget
+
+- Prefer `Read` and `grep`-via-`Bash` for citations. Use `Explore` only when the file/line is unknown.
+- Use `mcp__github__pull_request_read`, `mcp__github__issue_read`, and `mcp__github__list_pull_requests` for PR/issue artifacts.
+- Use `mcp__github__get_file_contents` for branch-protection-adjacent inspection (workflows on `main` vs. PR branch).
+- Do NOT call `Edit` or `Write` from this skill. It is read-only by design — diagnose, don't patch.
+
+## Stop conditions
+
+- All seven artifact classes inspected (or marked `missing-artifact / info`).
+- Every extracted claim has a verdict: aligned, drifted, or unverified.
+- Report rendered in the format specified in the main SKILL.md.
+
+Exit silently if the user later asks for fixes; the report is the deliverable.

--- a/.agents/skills/spec-drift-hunter/SKILL.md
+++ b/.agents/skills/spec-drift-hunter/SKILL.md
@@ -30,4 +30,4 @@ For a single-PR review, you can run the loop inline without delegation.
 - Every extracted claim has a verdict: aligned, drifted, or unverified.
 - Report rendered in the format specified in the main SKILL.md.
 
-Exit silently if the user later asks for fixes; the report is the deliverable.
+If the user later asks for fixes, do NOT exit silently and do NOT start patching. Reply with an explicit handoff: this skill is diagnostic-only — the deliverable is the report. Point them at the per-finding `Fix:` line and suggest a follow-up step (run `/review`, open a dedicated PR per fix, or hand off to a remediation agent). Then end your turn.

--- a/.agents/skills/spec-drift-hunter/agents/claim-extractor.md
+++ b/.agents/skills/spec-drift-hunter/agents/claim-extractor.md
@@ -1,0 +1,42 @@
+---
+name: claim-extractor
+description: Read-only agent that extracts every verifiable assertion from a repository's stated-intent artifacts (README, docs, contracts, issue bodies, PR descriptions) and returns them as a structured claim list with file:line provenance. Use as the first stage of the spec-drift-hunter loop.
+tools: Read, Bash, mcp__github__issue_read, mcp__github__pull_request_read, mcp__github__get_file_contents
+---
+
+# claim-extractor
+
+## Inputs
+- `scope`: `repo` | `pr:<number>` | `path:<glob>`
+- Optional: list of issue numbers to include.
+
+## What to do
+1. Enumerate stated-intent artifacts in scope:
+   - `README.md`, `docs/**/*.md`, `replit.md`, `CLAUDE.md`, `SECURITY.md`
+   - Contract files: `shared/schema.ts`, `schemas/**`, `openapi*.{yaml,json}`, Drizzle table definitions, Zod schemas
+   - Linked issues (via `mcp__github__issue_read`)
+   - PR description (via `mcp__github__pull_request_read`)
+2. For each artifact, extract concrete, verifiable assertions. Skip vague aspirations ("we value quality").
+3. Tag each claim with a category: `workflow`, `type-safety`, `auth`, `contract`, `test-coverage`, `feature-shipped`, `config`, `other`.
+
+## Output
+A JSON array of claim objects:
+
+```json
+[
+  {
+    "id": "C-001",
+    "category": "workflow",
+    "claim": "Semgrep pipeline added",
+    "source": "PR #123 body, line 4",
+    "verbatim": "This PR adds a Semgrep pipeline that blocks merges on findings."
+  },
+  ...
+]
+```
+
+## Constraints
+- Read-only. Never call `Edit`, `Write`, or anything that mutates state.
+- One claim per row. If a sentence makes three claims, emit three rows.
+- Always include `verbatim` so the reality-prober can disambiguate.
+- Cap output at 200 claims for a PR-scoped run; if more, prioritize categories: `auth` > `workflow` > `type-safety` > `contract` > others.

--- a/.agents/skills/spec-drift-hunter/agents/claim-extractor.md
+++ b/.agents/skills/spec-drift-hunter/agents/claim-extractor.md
@@ -13,7 +13,7 @@ tools: Read, Bash, mcp__github__issue_read, mcp__github__pull_request_read, mcp_
 ## What to do
 1. Enumerate stated-intent artifacts in scope:
    - `README.md`, `docs/**/*.md`, `replit.md`, `CLAUDE.md`, `SECURITY.md`
-   - Contract files: `shared/schema.ts`, `schemas/**`, `openapi*.{yaml,json}`, Drizzle table definitions, Zod schemas
+   - Contract files: shared/schema.ts, schemas/**, openapi*.{yaml,json}, Drizzle table definitions, Zod schemas, schema.prisma, *.sql
    - Linked issues (via `mcp__github__issue_read`)
    - PR description (via `mcp__github__pull_request_read`)
 2. For each artifact, extract concrete, verifiable assertions. Skip vague aspirations ("we value quality").

--- a/.agents/skills/spec-drift-hunter/agents/drift-reporter.md
+++ b/.agents/skills/spec-drift-hunter/agents/drift-reporter.md
@@ -23,9 +23,9 @@ tools: Read
 4. Sort findings by severity descending, then by source path.
 5. Compute the verdict:
    - `BLOCKED` — any `critical`
-   - `MAJOR DRIFT` — 2+ `high` or any `critical` cluster
-   - `MINOR DRIFT` — 1 `high` or only `medium`/`low`
-   - `ALIGNED` — only `info` or empty
+   - `MAJOR DRIFT` — 2+ `high` (no `critical`)
+   - `MINOR DRIFT` — 1 `high`, or only `medium` / `low`
+   - `ALIGNED` — only `info`, or empty
 
 ## Output
 Render exactly the markdown format specified in `.claude/skills/spec-drift-hunter/SKILL.md` under "Output format". Do not invent additional sections. Do not include emojis. Every finding must show Claim, Reality, Why it matters, Fix — in that order.

--- a/.agents/skills/spec-drift-hunter/agents/drift-reporter.md
+++ b/.agents/skills/spec-drift-hunter/agents/drift-reporter.md
@@ -1,0 +1,37 @@
+---
+name: drift-reporter
+description: Read-only agent that merges claim-extractor and reality-prober outputs into the final human-readable Spec Drift Report. Stage three of the spec-drift-hunter loop.
+tools: Read
+---
+
+# drift-reporter
+
+## Inputs
+- Claim list from `claim-extractor`.
+- Verdict list from `reality-prober`.
+- `scope` label for the report header.
+
+## What to do
+1. Join the two lists on `id`.
+2. Discard `aligned` rows from the findings section (count them in the summary).
+3. Assign final severity per the rubric in `.claude/skills/spec-drift-hunter/SKILL.md`:
+   - `critical` — security/correctness claim is false (auth, validation, secrets handling)
+   - `high` — workflow/gate claim is false
+   - `medium` — contract drift
+   - `low` — doc lag, no runtime impact
+   - `info` — missing artifact or unverifiable
+4. Sort findings by severity descending, then by source path.
+5. Compute the verdict:
+   - `BLOCKED` — any `critical`
+   - `MAJOR DRIFT` — 2+ `high` or any `critical` cluster
+   - `MINOR DRIFT` — 1 `high` or only `medium`/`low`
+   - `ALIGNED` — only `info` or empty
+
+## Output
+Render exactly the markdown format specified in `.claude/skills/spec-drift-hunter/SKILL.md` under "Output format". Do not invent additional sections. Do not include emojis. Every finding must show Claim, Reality, Why it matters, Fix — in that order.
+
+## Constraints
+- Read-only.
+- Do not re-verify claims; trust the reality-prober's verdicts.
+- If two findings cite the same root cause, group them under one finding with multiple sources rather than duplicating.
+- Keep "Fix" to one sentence. The smallest change that re-aligns claim and reality.

--- a/.agents/skills/spec-drift-hunter/agents/reality-prober.md
+++ b/.agents/skills/spec-drift-hunter/agents/reality-prober.md
@@ -19,7 +19,7 @@ For each claim, run the verification appropriate to its category:
 - If branch protection is implied, use `mcp__github__*` to confirm the check is required on the default branch.
 
 ### `type-safety`
-- `grep -rn` for bypass markers in the relevant tree: `# type: ignore`, `// @ts-ignore`, `// @ts-expect-error`, `: any`, `as any`, `// eslint-disable`, `mypy: ignore`, `strict: false`, `skipLibCheck: true`, `noImplicitAny: false`, `strictNullChecks: false`.
+- grep -rn for bypass markers in the relevant tree: # type: ignore, // @ts-ignore, // @ts-expect-error, : any, as any, // eslint-disable, // eslint-disable-next-line, mypy: ignore, strict: false, skipLibCheck: true, noImplicitAny: false, strictNullChecks: false.
 - Cross-reference `tsconfig*.json`, `mypy.ini`, `pyproject.toml`, `eslint.config.*`.
 
 ### `auth`

--- a/.agents/skills/spec-drift-hunter/agents/reality-prober.md
+++ b/.agents/skills/spec-drift-hunter/agents/reality-prober.md
@@ -46,7 +46,7 @@ A JSON array, one row per input claim:
     "verdict": "drifted",
     "evidence": [
       { "path": ".github/workflows/semgrep.yml", "line": 18, "note": "job defined" },
-      { "path": "GitHub branch protection", "line": null, "note": "semgrep NOT in required checks on main" }
+      { "path": "github:branch-protection/main", "line": 1, "note": "semgrep NOT in required checks on main (per mcp__github__* state)" }
     ],
     "severity_hint": "high"
   },
@@ -58,5 +58,5 @@ Verdicts: `aligned` | `drifted` | `unverified` (external state needed) | `missin
 
 ## Constraints
 - Read-only.
-- Every `drifted` verdict MUST cite at least one file:line as contrary evidence.
+- Every `drifted` verdict MUST cite at least one concrete location as contrary evidence — either a repo `file:line`, or an explicit external-source locator (e.g. `github:branch-protection/<branch>:<line>`, `npm:registry/<pkg>@<version>:<line>`) with a numeric `line` field. Never emit `"line": null` for a drifted finding.
 - If a claim cannot be verified from the repo alone, return `unverified` with a note about what external info is needed. Don't guess.

--- a/.agents/skills/spec-drift-hunter/agents/reality-prober.md
+++ b/.agents/skills/spec-drift-hunter/agents/reality-prober.md
@@ -1,0 +1,62 @@
+---
+name: reality-prober
+description: Read-only agent that takes a list of claims (from claim-extractor) and verifies each one against the actual implementation, workflows, and tests. Returns a per-claim verdict (aligned, drifted, unverified) with file:line evidence. Stage two of the spec-drift-hunter loop.
+tools: Read, Bash, Explore, mcp__github__get_file_contents, mcp__github__pull_request_read
+---
+
+# reality-prober
+
+## Inputs
+- The claim list emitted by `claim-extractor`.
+- `scope`: same scope passed to `claim-extractor`.
+
+## What to do
+For each claim, run the verification appropriate to its category:
+
+### `workflow`
+- Open the referenced `.github/workflows/*.yml`. Confirm the step exists.
+- Check for `continue-on-error: true`, `if: false`, or commented-out blocks that neuter it.
+- If branch protection is implied, use `mcp__github__*` to confirm the check is required on the default branch.
+
+### `type-safety`
+- `grep -rn` for bypass markers in the relevant tree: `# type: ignore`, `// @ts-ignore`, `// @ts-expect-error`, `: any`, `as any`, `// eslint-disable`, `mypy: ignore`, `strict: false`, `skipLibCheck: true`, `noImplicitAny: false`, `strictNullChecks: false`.
+- Cross-reference `tsconfig*.json`, `mypy.ini`, `pyproject.toml`, `eslint.config.*`.
+
+### `auth`
+- Locate the route/handler. Confirm the auth middleware (`requireAuth`, `requireAdmin`, equivalent) is actually applied.
+- Confirm rate-limit / CSRF middleware is wired if the claim mentions them.
+
+### `contract`
+- Match the documented endpoint/field against the implementation. Confirm the Zod/schema validator is imported AND called at the boundary, not just defined.
+
+### `test-coverage`
+- Find a test file that exercises the claimed behavior. Confirm it's in the runner's globs (`vitest.config.ts`, `pytest.ini`).
+- A file existing is not a passing test — open it and confirm the assertion.
+
+### `feature-shipped`
+- Diff the PR against base. Confirm files/symbols implementing the feature exist.
+
+## Output
+A JSON array, one row per input claim:
+
+```json
+[
+  {
+    "id": "C-001",
+    "verdict": "drifted",
+    "evidence": [
+      { "path": ".github/workflows/semgrep.yml", "line": 18, "note": "job defined" },
+      { "path": "GitHub branch protection", "line": null, "note": "semgrep NOT in required checks on main" }
+    ],
+    "severity_hint": "high"
+  },
+  ...
+]
+```
+
+Verdicts: `aligned` | `drifted` | `unverified` (external state needed) | `missing-artifact` (claim references something not present).
+
+## Constraints
+- Read-only.
+- Every `drifted` verdict MUST cite at least one file:line as contrary evidence.
+- If a claim cannot be verified from the repo alone, return `unverified` with a note about what external info is needed. Don't guess.

--- a/.claude/skills/reviewer-load-balancer/SKILL.md
+++ b/.claude/skills/reviewer-load-balancer/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: reviewer-load-balancer
+description: Decide which code reviewers (CodeRabbit, Gemini, Semgrep, CodeQL, Claude/Codex agents, human) should run on a PR, in what order, and on which files — so cheap PRs get cheap reviews and expensive reviewers are reserved for changes that warrant them. Use when opening a PR, when reviewer cost is showing up in budget, when a PR keeps re-triggering full review on trivial doc edits, or when the user asks "who should review this?", "skip AI review on this PR", "route this to the right reviewer", "is this PR worth a full review?". Output: a routing plan listing each reviewer to invoke, the file globs they should look at, the order, the skip rationale for reviewers that were excluded, and an estimated cost class.
+---
+
+# Reviewer Load Balancer
+
+A decision layer that sits in front of a multi-agent review ecosystem and routes review work to the cheapest reviewer that can answer the question at hand. The goal is to stop paying for full AI review on docs-only changes and to stop missing real risk on workflow/auth changes that got rubber-stamped.
+
+## When to invoke
+
+- A PR has just been opened and you need a review plan.
+- You're sweeping a backlog of stale PRs and need to triage which deserve attention.
+- The user says: "route reviewers for this PR", "who should look at this?", "is this PR worth a full review?", "balance review load", "skip review on this".
+- You're inside the `babysit-prs` / `loop` flow and want to avoid re-running expensive reviewers on every push.
+
+Do NOT invoke for: the actual review (use `/review` or the routed reviewer). This skill only PLANS the routing; the routed reviewers do the work.
+
+## The reviewer roster
+
+Treat each reviewer as having a fixed cost, latency, and competence profile. Update the table as new reviewers come online.
+
+| Reviewer | Cost | Latency | Best at | Bad at |
+|---|---|---|---|---|
+| **Semgrep** | low | seconds | Pattern-based code smells, known anti-patterns, security rules with high precision | Semantic / cross-file reasoning |
+| **CodeQL** | medium | minutes | Data-flow & taint analysis, deeper security findings | Style, formatting, intent |
+| **CodeRabbit** | medium | seconds-minutes | Line-by-line review comments, style/clarity, minor bugs | Architectural drift, security depth |
+| **Gemini** | medium | seconds | Broad PR summary, alternate-perspective review | Project-specific conventions |
+| **Claude/Codex agent** | high | seconds-minutes | Repo-aware review, project conventions, design-level critique, drift hunting | Bulk pattern-matching (Semgrep is cheaper) |
+| **Human reviewer** | very high | hours-days | Judgement calls, business context, irreversible decisions | Scale |
+
+## File-class routing table
+
+Classify every changed file into ONE class. Then union the reviewers for all classes present in the PR.
+
+| File class | Globs | Reviewers to invoke | Skip |
+|---|---|---|---|
+| **docs-only** | `**/*.md`, `docs/**`, `README*`, `CHANGELOG*`, `LICENSE*` | Claude (lightweight: typos, broken links, drift vs. code) | Semgrep, CodeQL, Gemini |
+| **workflow / CI** | `.github/workflows/**`, `.pre-commit-config.yaml`, `.circleci/**`, `Dockerfile*`, `docker-compose*.yml` | Semgrep (workflow rules), CodeQL (if available), Claude (drift hunter), **human if changes branch protection or required checks** | CodeRabbit |
+| **infra / IaC** | `*.tf`, `wrangler.toml`, `supabase/**`, `alembic.ini`, `migrations/**`, `cargo.toml` | Semgrep, Claude (review skill), human if production schema | CodeRabbit, Gemini |
+| **runtime Python** | `**/*.py` (non-test) | Ruff/mypy (lint+type), Semgrep, CodeQL, Claude | Gemini |
+| **runtime TS/JS** | `**/*.{ts,tsx,js,jsx}` (non-test) | ESLint, tsc, Semgrep, CodeRabbit, Claude | Gemini |
+| **tests** | `**/*.test.*`, `**/*.spec.*`, `tests/**` | Claude (assert the assertion is meaningful), test runner in CI | Semgrep, CodeQL |
+| **shared contracts** | `shared/schema.ts`, `schemas/**`, `openapi*.{yaml,json}`, Zod/Drizzle definitions | Claude (drift hunter), Semgrep, **human if API breaking** | Gemini |
+| **lockfiles** | `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Cargo.lock`, `poetry.lock`, `uv.lock` | npm audit / cargo audit / equivalent | All AI reviewers (diff is unreadable; trust the audit) |
+| **generated / vendored** | `dist/**`, `build/**`, `coverage/**`, `node_modules/**`, `*.min.js`, `vendor/**` | nothing | Everything (these should not be in a PR — flag the inclusion as a finding) |
+| **binary / unsupported** | `*.png`, `*.jpg`, `*.pdf`, `*.zip`, `*.wasm`, `*.bin` | nothing | All AI reviewers |
+| **secrets-adjacent** | `.env*`, `*.pem`, `*.key`, `credentials*`, `*secrets*` | Secret scanner (e.g., `mcp__github__run_secret_scanning`), human | All other AI reviewers (do not echo content) |
+
+## Routing rules
+
+Apply in order. First match wins per rule; rules accumulate per PR.
+
+1. **Skip rule.** If 100% of files are in `binary/unsupported` or `generated/vendored`, emit `review: SKIP` and stop. Cost: zero.
+2. **Secret rule.** If any file is `secrets-adjacent`, force a secret scan and a human review. Never send secret-adjacent content to a third-party reviewer (CodeRabbit, Gemini) — the file is excluded from their globs even if the PR also touches other classes.
+3. **Tiny-diff rule.** If the diff is ≤ 20 lines AND no file class above `docs-only` is touched AND no security-sensitive area is touched → lightweight Claude review only.
+4. **Workflow-gate rule.** If any `.github/workflows/**` or branch-protection-adjacent file is touched, ALWAYS include the spec-drift-hunter skill in the plan (workflow claims commonly drift from reality).
+5. **Auth / contract rule.** If any file under `server/middleware*`, `server/routes*`, `shared/schema*`, or anything matching `auth|session|csrf|rate.?limit` is touched → escalate Claude to "deep review" mode and add human reviewer.
+6. **Cost ceiling rule.** Do not invoke more than 4 distinct reviewers on a single PR unless one of the security/auth/workflow rules forced it. If the union exceeds 4, drop in this order: Gemini, CodeRabbit, CodeQL — keep Semgrep, Claude, and any human-required reviewer.
+7. **Re-push rule.** On a re-push to an open PR, only re-invoke reviewers whose covered files changed since the previous run. Doc-typo fixes don't re-trigger CodeQL.
+8. **Order rule.** Run cheap-and-fast first so they can short-circuit: Semgrep → CodeRabbit → Gemini → CodeQL → Claude → human. Human gets the AI findings as input.
+
+## Output format
+
+```
+# Reviewer Routing Plan — <PR ref or scope>
+
+## Diff summary
+- Files changed: <count>
+- Lines added/removed: +<a> / -<r>
+- File classes detected: <list>
+- Triggered rules: <list of rule names>
+
+## Reviewers to invoke (in order)
+1. <reviewer> — globs: <list>; rationale: <one line>; cost: <low|med|high>
+2. ...
+
+## Reviewers skipped
+- <reviewer> — reason: <one line>
+
+## Cost class
+<MINIMAL | LIGHT | STANDARD | DEEP | BLOCKED-ON-HUMAN>
+
+## Notes
+- <any heuristic overrides, e.g. "diff includes generated file dist/foo.js — flag this in PR description">
+```
+
+## Operating rules
+
+- **Plan only.** This skill does not run reviewers. It emits the plan. A separate step (or the user) invokes each reviewer.
+- **One classification per file.** A `.py` test file is `tests`, not `runtime Python`. Otherwise budgets double-count.
+- **Be explicit about skips.** Every excluded reviewer needs a one-line reason. Silent skips erode trust in the router.
+- **Don't route what you don't have.** If CodeQL or Gemini aren't configured in this repo, mark them `n/a` instead of pretending to schedule them. Check `.github/workflows/` for what's actually wired up.
+- **Re-classify on each push.** A PR that started doc-only and grew a workflow change crosses into `workflow/CI` and must re-route.
+- **Respect repo conventions.** This repo's `CLAUDE.md` documents `strictNullChecks: false` and `noImplicitAny: false` as known technical debt — don't waste a reviewer flagging those.
+
+## Examples
+
+**Example 1 — docs-only PR**
+- Files: `README.md`, `docs/foo.md`
+- Class union: `{docs-only}`
+- Triggered: tiny-diff rule (8 lines), rule 3
+- Plan: Claude (lightweight) only. Skip Semgrep, CodeQL, CodeRabbit, Gemini, human.
+- Cost class: MINIMAL
+
+**Example 2 — workflow YAML**
+- Files: `.github/workflows/ci.yml`, `.github/workflows/semgrep.yml`
+- Class union: `{workflow/CI}`
+- Triggered: workflow-gate rule (4)
+- Plan: Semgrep → CodeQL → Claude (with spec-drift-hunter skill) → human (because required checks may be affected).
+- Cost class: DEEP
+
+**Example 3 — runtime Python**
+- Files: `prompt_crafting/foo.py`, `prompt_crafting/bar.py`, `tests/test_foo.py`
+- Class union: `{runtime Python, tests}`
+- Triggered: none of the security/auth rules
+- Plan: Ruff + mypy → Semgrep → CodeQL → Claude. Skip Gemini (cost ceiling), skip CodeRabbit (Claude+CodeQL+Semgrep cover the same surface here).
+- Cost class: STANDARD
+
+**Example 4 — binary asset**
+- Files: `public/logo.png`, `attached_assets/diagram.pdf`
+- Class union: `{binary/unsupported}`
+- Triggered: skip rule (1)
+- Plan: SKIP. Optionally: verify files are tracked in LFS / not bloating the repo.
+- Cost class: MINIMAL
+
+**Example 5 — secret-adjacent leak risk**
+- Files: `.env.example`, `server/routes.ts`
+- Class union: `{secrets-adjacent, runtime TS/JS}`
+- Triggered: secret rule (2), then runtime TS rules
+- Plan: secret scanner → human (mandatory) → Semgrep → Claude. CodeRabbit and Gemini get the `runtime TS/JS` files only — `.env.example` is excluded from their input.
+- Cost class: BLOCKED-ON-HUMAN
+
+## Anti-patterns to avoid
+
+- Invoking every reviewer on every PR "to be safe" — that is the problem this skill exists to solve.
+- Skipping a reviewer silently. If you skip, say which reviewer and why.
+- Routing CodeRabbit/Gemini to `.env*` or secret-adjacent files. Even if the file is a placeholder, the precedent is bad.
+- Treating a re-push as a brand-new PR. Use the re-push rule (7) and only re-run reviewers whose files changed.
+- Forgetting that human review is also a reviewer to be scheduled — it has the highest cost and must be reserved for changes that justify it.

--- a/.claude/skills/reviewer-load-balancer/SKILL.md
+++ b/.claude/skills/reviewer-load-balancer/SKILL.md
@@ -45,7 +45,7 @@ Classify every changed file into ONE class. Then union the reviewers for all cla
 | **lockfiles** | `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Cargo.lock`, `poetry.lock`, `uv.lock` | npm audit / cargo audit / equivalent | All AI reviewers (diff is unreadable; trust the audit) |
 | **generated / vendored** | `dist/**`, `build/**`, `coverage/**`, `node_modules/**`, `*.min.js`, `vendor/**` | nothing | Everything (these should not be in a PR — flag the inclusion as a finding) |
 | **binary / unsupported** | `*.png`, `*.jpg`, `*.pdf`, `*.zip`, `*.wasm`, `*.bin` | nothing | All AI reviewers |
-| **secrets-adjacent** | `.env*`, `*.pem`, `*.key`, `credentials*`, `*secrets*` | Secret scanner (e.g., `mcp__github__run_secret_scanning`), human | All other AI reviewers (do not echo content) |
+| **secrets-adjacent** | `.env*`, `*.pem`, `*.key`, `credentials*`, `*secrets*` | Secret scanner (e.g., `mcp__github__run_secret_scanning`), human | Exclude these files from third-party AI reviewer inputs (CodeRabbit, Gemini); other non-secret files in the same PR may still be reviewed per their own class rules. Do not echo file contents in any reviewer prompt. |
 
 ## Routing rules
 
@@ -62,7 +62,7 @@ Apply in order. First match wins per rule; rules accumulate per PR.
 
 ## Output format
 
-```
+```markdown
 # Reviewer Routing Plan — <PR ref or scope>
 
 ## Diff summary

--- a/.claude/skills/spec-drift-hunter/SKILL.md
+++ b/.claude/skills/spec-drift-hunter/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: spec-drift-hunter
+description: Hunt architectural entropy by detecting divergence between what a repository CLAIMS (README, contracts, workflows, tests, issue intent, PR description) and what the code ACTUALLY does (implementation, configuration, CI gates, type coverage). Use when reviewing a PR, auditing a branch before release, triaging stale issues, or whenever you need to answer "do the docs/specs/tests still match the code?" Examples: a PR titled "Semgrep pipeline added" where the workflow exists but no branch protection enforces it; a README that promises "strict typed validation" while new files opt out of mypy; a contract that documents `POST /api/foo` while the route handler returns 404; an issue closed as "fixed" with no corresponding test. Output: a structured drift report grouped by severity with file:line citations and a recommended remediation per finding.
+---
+
+# Spec Drift Hunter
+
+A loop that compares **stated intent** against **realized behavior** across seven artifact classes and emits a drift report.
+
+## When to invoke
+
+Run this skill when ANY of these are true:
+
+- You are reviewing a PR and want to verify the description matches the diff.
+- A release is being cut and you need to know which README/contract claims are no longer true.
+- An issue is being closed and you want to confirm the fix is actually shipped, gated, and tested.
+- The user asks: "are the docs still accurate?", "is X actually enforced?", "does the workflow gate what it says it does?", "audit for spec drift", "find architectural entropy", "hunt drift".
+
+Do NOT invoke for: pure code review (use `/review`), pure security review (use `/security-review`), or generic refactoring requests.
+
+## The seven artifacts
+
+Always pull evidence from all seven. Missing artifacts are themselves a finding (record as `missing-artifact` severity `info`).
+
+| # | Artifact | Where it lives | Encodes |
+|---|---|---|---|
+| 1 | README / docs | `README.md`, `docs/`, `replit.md`, `CLAUDE.md` | Project promises, supported features, configuration claims |
+| 2 | Contracts | `shared/schema.ts`, `schemas/`, OpenAPI/JSON-schema files, Zod schemas, Drizzle tables | API shape, data shape, validation rules |
+| 3 | Workflows | `.github/workflows/*.yml`, `.pre-commit-config.yaml`, branch protection (via `mcp__github__*`) | What CI actually enforces, what gates merges |
+| 4 | Tests | `**/*.test.*`, `**/*.spec.*`, `vitest.config.ts`, `pytest.ini` | What behavior is exercised and asserted |
+| 5 | Implementation | `client/src/**`, `server/**`, `src/**`, route handlers, middleware | What the code actually does at runtime |
+| 6 | Issue intent | GitHub issues referenced by the PR (`Closes #N`, `Fixes #N`) — fetch via `mcp__github__issue_read` | What the user/maintainer asked for |
+| 7 | PR description | The PR body itself — fetch via `mcp__github__pull_request_read` | What the author claims this change does |
+
+## Loop
+
+1. **Collect.** Read all seven artifacts for the scope under review (whole repo, single PR, single subsystem). Use parallel tool calls. For PR reviews, diff `HEAD` against the merge base.
+2. **Extract claims.** From artifacts 1, 2, 6, 7 — pull every concrete assertion: "X is enforced", "POST /api/foo returns Y", "field Z is required", "this PR adds W". One claim per row. Keep file:line provenance.
+3. **Verify each claim** against artifacts 3, 4, 5:
+   - **Workflow claim?** Open the YAML. Confirm the step exists, the job is required, the check is in branch protection, and the failure mode is `exit 1` not `continue-on-error: true`.
+   - **Type/lint claim?** `grep` for `# type: ignore`, `// @ts-ignore`, `// eslint-disable`, `any`, `mypy: ignore`, `strict: false`, `skipLibCheck` in the changed files.
+   - **Contract claim?** Grep the implementation for a matching route/handler/field. Confirm the Zod/Drizzle schema is actually imported and validated at the boundary.
+   - **Test claim?** Confirm a test file exists, asserts the claimed behavior, and is included in the test runner's globs.
+   - **Issue intent?** Confirm the change set actually addresses the linked issue's acceptance criteria.
+4. **Classify each finding** by severity (see rubric below).
+5. **Emit the report** in the format below. Cite `path:line` for every claim and every piece of contrary evidence.
+
+## Severity rubric
+
+- **critical** — Security or correctness claim is false (e.g., "auth required" but route is open; "validated input" but no schema is called; "secrets scanning enabled" but the job has `continue-on-error: true`).
+- **high** — Workflow/gate claim is false (CI step exists but is not required; lint/type promise made but bypasses are merged).
+- **medium** — Contract drift (README/schema documents a field or endpoint that no longer exists, or vice versa).
+- **low** — Documentation lag (description is stale but no runtime impact).
+- **info** — Missing artifact, undocumented behavior, or a claim that cannot be verified from the repo alone.
+
+## Output format
+
+```
+# Spec Drift Report — <scope>
+
+## Summary
+- Artifacts inspected: <count>
+- Claims extracted: <count>
+- Drift findings: <critical> critical, <high> high, <medium> medium, <low> low
+- Verdict: <ALIGNED | MINOR DRIFT | MAJOR DRIFT | BLOCKED>
+
+## Findings
+
+### [SEVERITY] <one-line title>
+- **Claim:** <verbatim, with file:line>
+- **Reality:** <what the code/config actually does, with file:line>
+- **Why it matters:** <one sentence>
+- **Fix:** <smallest change that re-aligns claim and reality — either update the claim or update the code>
+
+(repeat per finding, sorted by severity desc)
+
+## Unverified claims
+<list claims that need external context (production config, secrets, third-party state) to verify>
+```
+
+## Operating rules
+
+- **Cite or it didn't happen.** Every claim and every piece of contrary evidence MUST carry a `path:line` reference. No vague "the workflow doesn't enforce this" — point at the YAML line.
+- **Drift is symmetric.** Either the claim is wrong or the code is wrong. Recommend whichever fix is smaller. Don't default to "update the code."
+- **Do not fabricate findings.** If the seven artifacts agree, say so explicitly (`verdict: ALIGNED`). A clean report is a valid result.
+- **Don't auto-fix.** This skill diagnoses; it does not patch. If the user wants fixes applied, they'll ask after seeing the report.
+- **Respect scope.** A PR-scoped run only flags drift introduced or worsened by that PR. A repo-wide audit flags everything.
+- **Branch protection is invisible without GitHub.** When the PR/branch-protection state matters, use `mcp__github__*` tools; if unavailable, mark those claims `info / unverified` rather than guessing.
+
+## Examples
+
+**Example 1 — Workflow gate claim is false (high)**
+- Claim: PR title says "Semgrep pipeline added" (`PR #123 body`)
+- Reality: `.github/workflows/semgrep.yml:18` defines the job, but `mcp__github__pull_request_read` shows the `semgrep` check is not in required status checks for `main`.
+- Fix: Add `semgrep` to required checks, OR change the PR title/description to "Semgrep workflow added (not yet enforced)".
+
+**Example 2 — Type-safety claim is false (high)**
+- Claim: `README.md:42` — "strict typed validation throughout"
+- Reality: `server/routes.ts:88` uses `req.body as any`; `CLAUDE.md:128` documents `strictNullChecks: false` and `noImplicitAny: false` as standing technical debt.
+- Fix: Update README to match the documented technical debt, OR file an issue to actually enable strict mode and remove the `as any` casts.
+
+**Example 3 — Contract drift (medium)**
+- Claim: `README.md:88` documents `PATCH /api/test-runs/:id/notes`
+- Reality: `server/routes.ts` exposes `PATCH /api/test-runs/:id/ratings` (per `CLAUDE.md:80`); no `/notes` handler exists.
+- Fix: Update README to reflect the actual route, OR add the missing handler if the documented endpoint was the intended design.
+
+## Anti-patterns to avoid
+
+- Reporting "the README is out of date" without naming the specific stale claim and the contradicting code.
+- Treating absence of evidence as evidence of absence (e.g., "I didn't find a test, therefore none exists"). Search broadly first.
+- Inflating severity. A typo in a docstring is `low`, not `critical`. Reserve `critical` for security/correctness lies.
+- Recommending large refactors. The remediation is always the smallest change that makes claim and reality agree.

--- a/.claude/skills/spec-drift-hunter/SKILL.md
+++ b/.claude/skills/spec-drift-hunter/SKILL.md
@@ -55,7 +55,7 @@ Always pull evidence from all seven. Missing artifacts are themselves a finding 
 
 ## Output format
 
-```
+```markdown
 # Spec Drift Report — <scope>
 
 ## Summary

--- a/.github/scripts/ralph_agents.py
+++ b/.github/scripts/ralph_agents.py
@@ -1,0 +1,734 @@
+#!/usr/bin/env python3
+"""Ralph: the six agents.
+
+Each agent is standalone — no agent imports another. They share only
+the data contracts in ralph_models. Every agent exposes:
+
+    class FooAgent:
+        name: AgentName
+        def run(self, state: PRState, memory: RalphMemory) -> AgentResult
+
+The orchestrator composes them. Hard stops in GovernanceSentinel
+cannot be overridden by any downstream agent.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Iterable
+
+from ralph_models import (
+    AgentName,
+    AgentResult,
+    Finding,
+    PRClass,
+    PRState,
+    RalphMemory,
+    ReviewThread,
+    RiskTier,
+    RunStatus,
+    Severity,
+    ThreadCluster,
+    _tokenise,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. TriageAgent — classify a PR into one PRClass and normalise labels
+# ---------------------------------------------------------------------------
+
+
+_DOCS_GLOBS = (
+    "README", "CHANGELOG", "LICENSE", "docs/", ".md",
+)
+_WORKFLOW_GLOBS = (
+    ".github/workflows/", ".pre-commit-config",
+    "Dockerfile", "docker-compose",
+)
+_INFRA_GLOBS = (
+    ".tf", "wrangler.toml", "supabase/",
+    "alembic.ini", "migrations/", "cargo.toml",
+)
+_CONTRACT_GLOBS = (
+    "shared/schema", "schemas/", "openapi", "schema.prisma",
+)
+_PY_SUFFIXES = (".py",)
+_TS_SUFFIXES = (".ts", ".tsx", ".js", ".jsx")
+_TEST_MARKERS = (".test.", ".spec.", "tests/", "/test/")
+
+
+def _file_class(path: str) -> PRClass:
+    p = path.lower()
+    pp = PurePosixPath(p)
+    if any(m in p for m in _TEST_MARKERS):
+        # Tests count as the runtime language they're written in,
+        # but the orchestrator treats tests-only PRs separately via
+        # metadata; classification stays runtime to keep one class.
+        if pp.suffix in _PY_SUFFIXES:
+            return PRClass.RUNTIME_PY
+        if pp.suffix in _TS_SUFFIXES:
+            return PRClass.RUNTIME_TS
+    if any(g in p for g in _DOCS_GLOBS) and pp.suffix == ".md":
+        return PRClass.DOCS
+    if any(g in p for g in _WORKFLOW_GLOBS):
+        return PRClass.WORKFLOW
+    if any(g in p for g in _CONTRACT_GLOBS):
+        return PRClass.CONTRACT
+    if any(g in p for g in _INFRA_GLOBS):
+        return PRClass.INFRA
+    if pp.suffix in _PY_SUFFIXES:
+        return PRClass.RUNTIME_PY
+    if pp.suffix in _TS_SUFFIXES:
+        return PRClass.RUNTIME_TS
+    if pp.suffix == ".md":
+        return PRClass.DOCS
+    return PRClass.MIXED
+
+
+class TriageAgent:
+    name = AgentName.TRIAGE
+
+    def run(self, state: PRState, memory: RalphMemory) -> AgentResult:
+        if not state.changed_files:
+            return AgentResult(
+                agent=self.name,
+                status=RunStatus.SKIP,
+                metadata={"pr_class": PRClass.DOCS.value, "reason": "empty"},
+            )
+        classes = [_file_class(f) for f in state.changed_files]
+        unique = sorted({c for c in classes})
+        if len(unique) == 1:
+            pr_class = unique[0]
+        elif PRClass.CONTRACT in unique or PRClass.WORKFLOW in unique:
+            # Promote to the most risk-sensitive class present.
+            pr_class = (
+                PRClass.CONTRACT
+                if PRClass.CONTRACT in unique
+                else PRClass.WORKFLOW
+            )
+        else:
+            pr_class = PRClass.MIXED
+
+        findings: list[Finding] = []
+        if state.total_loc > 1000:
+            findings.append(
+                Finding(
+                    agent=self.name,
+                    severity=Severity.MEDIUM,
+                    message=(
+                        f"Large diff ({state.total_loc} LOC). Consider "
+                        "splitting before reviewer dispatch."
+                    ),
+                )
+            )
+
+        return AgentResult(
+            agent=self.name,
+            status=RunStatus.OK,
+            findings=findings,
+            metadata={
+                "pr_class": pr_class.value,
+                "file_classes": [c.value for c in classes],
+                "unique_classes": [c.value for c in unique],
+                "loc": state.total_loc,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. GovernanceSentinel — risk scoring + non-overrideable hard stops
+# ---------------------------------------------------------------------------
+
+
+# Compiled once. Each pattern is paired with a Severity and a short id.
+_SECRET_PATTERNS: tuple[tuple[str, re.Pattern[str], Severity], ...] = (
+    (
+        "aws-akid",
+        re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+        Severity.CRITICAL,
+    ),
+    (
+        "github-pat",
+        re.compile(r"\bghp_[A-Za-z0-9]{36}\b"),
+        Severity.CRITICAL,
+    ),
+    (
+        "github-oauth",
+        re.compile(r"\bgho_[A-Za-z0-9]{36}\b"),
+        Severity.CRITICAL,
+    ),
+    (
+        "slack-token",
+        re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{10,}\b"),
+        Severity.CRITICAL,
+    ),
+    (
+        "openai-key",
+        re.compile(r"\bsk-[A-Za-z0-9]{32,}\b"),
+        Severity.CRITICAL,
+    ),
+    (
+        "anthropic-key",
+        re.compile(r"\bsk-ant-[A-Za-z0-9-]{32,}\b"),
+        Severity.CRITICAL,
+    ),
+    (
+        "private-key-block",
+        re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+        Severity.CRITICAL,
+    ),
+    (
+        "generic-secret-kv",
+        re.compile(
+            r"(?:password|secret|api[_-]?key|token)\s*[:=]\s*"
+            r"[\"'][A-Za-z0-9_\-]{12,}[\"']",
+            re.IGNORECASE,
+        ),
+        Severity.HIGH,
+    ),
+)
+
+
+_SECRET_FILE_GLOBS = (
+    ".env", ".pem", ".key", "credentials", "secrets",
+)
+
+
+@dataclass
+class _RiskInput:
+    pr_class: PRClass
+    loc: int
+    age_days: float
+    unresolved_threads: int
+    secret_hits: int
+    is_draft: bool
+
+
+class GovernanceSentinel:
+    name = AgentName.SENTINEL
+
+    def run(self, state: PRState, memory: RalphMemory) -> AgentResult:
+        findings: list[Finding] = []
+        secret_hits = 0
+
+        # Hard stop #1: secret-adjacent files in the diff.
+        for path in state.changed_files:
+            low = path.lower()
+            if any(g in low for g in _SECRET_FILE_GLOBS):
+                findings.append(
+                    Finding(
+                        agent=self.name,
+                        severity=Severity.HIGH,
+                        message=(
+                            f"Secret-adjacent path in diff: {path}. "
+                            "Human review required."
+                        ),
+                        path=path,
+                        rule_id="secret-adjacent-path",
+                    )
+                )
+
+        # Hard stop #2: secret patterns in the PR title or body.
+        # (We do NOT scan file contents here — that's CI's job. We scan
+        # what we can see from the PR metadata, which is what gets
+        # echoed in audit logs.)
+        for haystack, src in (
+            (state.title, "title"),
+            (state.body, "body"),
+        ):
+            for rule_id, pat, sev in _SECRET_PATTERNS:
+                if pat.search(haystack):
+                    secret_hits += 1
+                    findings.append(
+                        Finding(
+                            agent=self.name,
+                            severity=sev,
+                            message=(
+                                f"Secret-like pattern '{rule_id}' "
+                                f"found in PR {src}. Rotate immediately."
+                            ),
+                            rule_id=rule_id,
+                        )
+                    )
+
+        # Risk score in [0, 1].
+        risk = self._score(
+            _RiskInput(
+                pr_class=_resolve_pr_class(state, memory),
+                loc=state.total_loc,
+                age_days=state.age_days,
+                unresolved_threads=len(state.unresolved_threads),
+                secret_hits=secret_hits,
+                is_draft=state.is_draft,
+            )
+        )
+        tier = self._tier(risk, has_hard_stop=secret_hits > 0 or any(
+            f.rule_id == "secret-adjacent-path" for f in findings
+        ))
+
+        status = (
+            RunStatus.BLOCK
+            if tier is RiskTier.BLOCK
+            else RunStatus.OK
+        )
+        return AgentResult(
+            agent=self.name,
+            status=status,
+            findings=findings,
+            metadata={
+                "risk": round(risk, 3),
+                "tier": tier.value,
+                "secret_hits": secret_hits,
+            },
+        )
+
+    @staticmethod
+    def _score(inp: _RiskInput) -> float:
+        score = 0.0
+        if inp.pr_class is PRClass.WORKFLOW:
+            score += 0.45
+        elif inp.pr_class is PRClass.CONTRACT:
+            score += 0.4
+        elif inp.pr_class is PRClass.INFRA:
+            score += 0.3
+        elif inp.pr_class is PRClass.RUNTIME_PY:
+            score += 0.2
+        elif inp.pr_class is PRClass.RUNTIME_TS:
+            score += 0.2
+        elif inp.pr_class is PRClass.MIXED:
+            score += 0.25
+        else:  # DOCS
+            score += 0.05
+
+        if inp.loc > 2000:
+            score += 0.2
+        elif inp.loc > 500:
+            score += 0.1
+
+        if inp.age_days > 14:
+            score += 0.1
+        elif inp.age_days > 30:
+            score += 0.2
+
+        if inp.unresolved_threads >= 8:
+            score += 0.15
+        elif inp.unresolved_threads >= 3:
+            score += 0.05
+
+        if inp.secret_hits > 0:
+            score = 1.0
+
+        if inp.is_draft:
+            score *= 0.75
+
+        return max(0.0, min(1.0, score))
+
+    @staticmethod
+    def _tier(risk: float, has_hard_stop: bool) -> RiskTier:
+        if has_hard_stop or risk >= 0.85:
+            return RiskTier.BLOCK
+        if risk >= 0.6:
+            return RiskTier.HIGH
+        if risk >= 0.3:
+            return RiskTier.MEDIUM
+        return RiskTier.LOW
+
+
+def _resolve_pr_class(
+    state: PRState, memory: RalphMemory
+) -> PRClass:
+    """Look up the most recent TriageAgent classification, fall back."""
+
+    for entry in reversed(list(memory.find(pr_number=state.number))):
+        if entry.payload.get("agent") == AgentName.TRIAGE.value:
+            val = (
+                entry.payload.get("result", {}).get("metadata", {}).get(
+                    "pr_class"
+                )
+            )
+            if val:
+                try:
+                    return PRClass(val)
+                except ValueError:
+                    pass
+    # Triage runs before sentinel, so this only fires for the very
+    # first sentinel run on a brand-new PR. Best effort:
+    if not state.changed_files:
+        return PRClass.DOCS
+    return _file_class(state.changed_files[0])
+
+
+# ---------------------------------------------------------------------------
+# 3. ConvergenceLoop — bounded deterministic repair
+# ---------------------------------------------------------------------------
+
+
+MAX_CONVERGENCE_ATTEMPTS = 3
+
+
+class ConvergenceLoop:
+    name = AgentName.CONVERGENCE
+
+    def run(self, state: PRState, memory: RalphMemory) -> AgentResult:
+        prior = memory.count_convergence_attempts(state.number)
+        if state.all_checks_green:
+            return AgentResult(
+                agent=self.name,
+                status=RunStatus.OK,
+                metadata={
+                    "attempt": prior + 1,
+                    "checks_green": True,
+                    "action": "no-op",
+                },
+            )
+
+        if prior >= MAX_CONVERGENCE_ATTEMPTS:
+            return AgentResult(
+                agent=self.name,
+                status=RunStatus.ESCALATE,
+                findings=[
+                    Finding(
+                        agent=self.name,
+                        severity=Severity.HIGH,
+                        message=(
+                            f"PR #{state.number} has exhausted "
+                            f"{MAX_CONVERGENCE_ATTEMPTS} convergence "
+                            "attempts. Escalating to human review."
+                        ),
+                        rule_id="convergence-exhausted",
+                    )
+                ],
+                metadata={
+                    "attempt": prior + 1,
+                    "checks_green": False,
+                    "action": "escalate",
+                },
+            )
+
+        failing = sorted(
+            [
+                name
+                for name, conc in state.check_states.items()
+                if conc.upper() not in ("SUCCESS", "PENDING", "NEUTRAL", "SKIPPED")
+            ]
+        )
+        plan = _repair_plan(failing)
+        return AgentResult(
+            agent=self.name,
+            status=RunStatus.OK,
+            findings=[
+                Finding(
+                    agent=self.name,
+                    severity=Severity.MEDIUM,
+                    message=(
+                        f"Attempt {prior + 1}/{MAX_CONVERGENCE_ATTEMPTS}: "
+                        f"failing checks: {', '.join(failing) or 'unknown'}."
+                    ),
+                    rule_id="convergence-attempt",
+                )
+            ],
+            metadata={
+                "attempt": prior + 1,
+                "checks_green": False,
+                "failing_checks": failing,
+                "repair_plan": plan,
+                "action": "retry",
+            },
+        )
+
+
+def _repair_plan(failing_checks: list[str]) -> list[str]:
+    plan: list[str] = []
+    for name in failing_checks:
+        n = name.lower()
+        if "lint" in n:
+            plan.append(f"re-run linter and auto-fix where possible ({name})")
+        elif "type" in n or "tsc" in n or "mypy" in n:
+            plan.append(f"surface type errors and patch annotations ({name})")
+        elif "test" in n:
+            plan.append(f"re-run flaky tests; if persistent, file issue ({name})")
+        elif "build" in n:
+            plan.append(f"rebuild from clean cache ({name})")
+        elif "security" in n or "semgrep" in n or "codeql" in n:
+            plan.append(f"triage security findings (no auto-fix) ({name})")
+        else:
+            plan.append(f"manual investigation required ({name})")
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# 4. ReviewDebtCompressor — cluster N threads into M deduped clusters
+# ---------------------------------------------------------------------------
+
+
+JACCARD_MERGE_THRESHOLD = 0.55
+
+
+class ReviewDebtCompressor:
+    name = AgentName.COMPRESSOR
+
+    def run(self, state: PRState, memory: RalphMemory) -> AgentResult:
+        threads = state.unresolved_threads
+        if not threads:
+            return AgentResult(
+                agent=self.name,
+                status=RunStatus.SKIP,
+                metadata={"threads_in": 0, "clusters_out": 0},
+            )
+        clusters = _cluster_threads(threads)
+        return AgentResult(
+            agent=self.name,
+            status=RunStatus.OK,
+            metadata={
+                "threads_in": len(threads),
+                "clusters_out": len(clusters),
+                "compression_ratio": round(
+                    len(clusters) / max(1, len(threads)), 3
+                ),
+                "clusters": [c.as_dict() for c in clusters],
+            },
+        )
+
+
+def _cluster_threads(threads: list[ReviewThread]) -> list[ThreadCluster]:
+    """Greedy Jaccard clustering on tokenised thread bodies."""
+
+    clusters: list[list[ReviewThread]] = []
+    sigs: list[set[str]] = []
+    for t in threads:
+        toks = t.tokens()
+        placed = False
+        for i, sig in enumerate(sigs):
+            j = _jaccard(toks, sig)
+            if j >= JACCARD_MERGE_THRESHOLD:
+                clusters[i].append(t)
+                sigs[i] = sig | toks
+                placed = True
+                break
+        if not placed:
+            clusters.append([t])
+            sigs.append(toks)
+    out: list[ThreadCluster] = []
+    for group in clusters:
+        rep = group[0]
+        summary = _summarise(rep.body)
+        # Confidence = average pairwise jaccard within the cluster.
+        if len(group) == 1:
+            conf = 1.0
+        else:
+            pairs = []
+            for i in range(len(group)):
+                for j in range(i + 1, len(group)):
+                    pairs.append(
+                        _jaccard(group[i].tokens(), group[j].tokens())
+                    )
+            conf = sum(pairs) / len(pairs) if pairs else 1.0
+        out.append(
+            ThreadCluster(
+                representative_id=rep.thread_id,
+                member_ids=[t.thread_id for t in group],
+                summary=summary,
+                confidence=conf,
+            )
+        )
+    return out
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a and not b:
+        return 1.0
+    inter = a & b
+    union = a | b
+    return len(inter) / max(1, len(union))
+
+
+def _summarise(body: str, max_chars: int = 140) -> str:
+    line = " ".join(body.split())
+    if len(line) <= max_chars:
+        return line
+    return line[: max_chars - 1] + "…"
+
+
+# ---------------------------------------------------------------------------
+# 5. InlineThreadResolver — per-thread reply strategy
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ThreadAction:
+    thread_id: str
+    strategy: str
+    reply: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "thread_id": self.thread_id,
+            "strategy": self.strategy,
+            "reply": self.reply,
+        }
+
+
+_RESOLVED_PHRASES = (
+    "lgtm", "approved", "ok thanks", "ack",
+)
+_QUESTION_MARKERS = ("?",)
+_NIT_MARKERS = ("nit:", "nitpick", "style:")
+
+
+class InlineThreadResolver:
+    name = AgentName.INLINE
+
+    def run(self, state: PRState, memory: RalphMemory) -> AgentResult:
+        actions: list[ThreadAction] = []
+        findings: list[Finding] = []
+        for t in state.unresolved_threads:
+            body_l = t.body.lower()
+            if any(p in body_l for p in _RESOLVED_PHRASES):
+                strategy = "resolve-acknowledged"
+                reply = (
+                    "Marking this thread as acknowledged based on the "
+                    "approving language above."
+                )
+            elif any(m in body_l for m in _NIT_MARKERS):
+                strategy = "defer-nit"
+                reply = (
+                    "Captured as a nit — tracked in the backlog, not "
+                    "blocking this PR."
+                )
+            elif any(q in t.body for q in _QUESTION_MARKERS):
+                strategy = "answer-question"
+                reply = (
+                    "Question received. Will respond with evidence in "
+                    "a follow-up commit or comment."
+                )
+                findings.append(
+                    Finding(
+                        agent=self.name,
+                        severity=Severity.LOW,
+                        message=(
+                            f"Open question in thread {t.thread_id} "
+                            "needs an evidence-backed reply."
+                        ),
+                        path=t.path,
+                        line=t.line,
+                        rule_id="open-question",
+                    )
+                )
+            else:
+                strategy = "human-escalate"
+                reply = (
+                    "Routing this comment to a human reviewer — the "
+                    "automated resolver cannot infer a confident reply."
+                )
+                findings.append(
+                    Finding(
+                        agent=self.name,
+                        severity=Severity.MEDIUM,
+                        message=(
+                            f"Thread {t.thread_id} needs human review."
+                        ),
+                        path=t.path,
+                        line=t.line,
+                        rule_id="needs-human",
+                    )
+                )
+            actions.append(
+                ThreadAction(
+                    thread_id=t.thread_id,
+                    strategy=strategy,
+                    reply=reply,
+                )
+            )
+        return AgentResult(
+            agent=self.name,
+            status=RunStatus.OK,
+            findings=findings,
+            metadata={
+                "threads": len(state.unresolved_threads),
+                "actions": [a.as_dict() for a in actions],
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. BackpressureGovernor — enforce ceilings
+# ---------------------------------------------------------------------------
+
+
+LOC_CEILING = 2500
+AGE_CEILING_DAYS = 30.0
+THREAD_CEILING = 25
+
+
+class BackpressureGovernor:
+    name = AgentName.BACKPRESSURE
+
+    def run(self, state: PRState, memory: RalphMemory) -> AgentResult:
+        findings: list[Finding] = []
+        if state.total_loc > LOC_CEILING:
+            findings.append(
+                Finding(
+                    agent=self.name,
+                    severity=Severity.HIGH,
+                    message=(
+                        f"LOC ceiling exceeded: {state.total_loc} > "
+                        f"{LOC_CEILING}. Split this PR."
+                    ),
+                    rule_id="loc-ceiling",
+                )
+            )
+        if state.age_days > AGE_CEILING_DAYS:
+            findings.append(
+                Finding(
+                    agent=self.name,
+                    severity=Severity.MEDIUM,
+                    message=(
+                        f"Age ceiling exceeded: {state.age_days:.1f}d > "
+                        f"{AGE_CEILING_DAYS:.0f}d. Rebase or close."
+                    ),
+                    rule_id="age-ceiling",
+                )
+            )
+        if len(state.unresolved_threads) > THREAD_CEILING:
+            findings.append(
+                Finding(
+                    agent=self.name,
+                    severity=Severity.MEDIUM,
+                    message=(
+                        f"Thread ceiling exceeded: "
+                        f"{len(state.unresolved_threads)} > "
+                        f"{THREAD_CEILING}. Compressor will dedupe but "
+                        "consider closing & re-opening."
+                    ),
+                    rule_id="thread-ceiling",
+                )
+            )
+        status = RunStatus.OK if not findings else RunStatus.ESCALATE
+        return AgentResult(
+            agent=self.name,
+            status=status,
+            findings=findings,
+            metadata={
+                "loc": state.total_loc,
+                "age_days": state.age_days,
+                "unresolved_threads": len(state.unresolved_threads),
+                "ceilings": {
+                    "loc": LOC_CEILING,
+                    "age_days": AGE_CEILING_DAYS,
+                    "threads": THREAD_CEILING,
+                },
+            },
+        )
+
+
+__all__ = [
+    "BackpressureGovernor",
+    "ConvergenceLoop",
+    "GovernanceSentinel",
+    "InlineThreadResolver",
+    "MAX_CONVERGENCE_ATTEMPTS",
+    "ReviewDebtCompressor",
+    "TriageAgent",
+]

--- a/.github/scripts/ralph_models.py
+++ b/.github/scripts/ralph_models.py
@@ -1,0 +1,732 @@
+#!/usr/bin/env python3
+"""Ralph: data contracts, hash-chained memory, and gh CLI wrapper.
+
+This module defines the immutable types every Ralph agent reads/writes.
+No agent logic lives here. No agent imports another agent. The state
+flows: GH -> PRState -> AgentResult -> RalphMemory.
+
+The memory store is hash-chained (Spec Kit v2.2 audit pattern): each
+entry stores the SHA-256 of (prev_hash || canonical_json(payload)),
+so any tampering with an earlier entry invalidates every subsequent
+hash. Verify with `RalphMemory.verify_chain()`.
+"""
+
+from __future__ import annotations
+
+import enum
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class PRClass(str, enum.Enum):
+    """Coarse PR classification used by every downstream agent."""
+
+    DOCS = "docs"
+    WORKFLOW = "workflow"
+    RUNTIME_PY = "runtime-py"
+    RUNTIME_TS = "runtime-ts"
+    INFRA = "infra"
+    CONTRACT = "contract"
+    MIXED = "mixed"
+
+
+class RiskTier(str, enum.Enum):
+    """GovernanceSentinel risk tier. BLOCK is non-overrideable."""
+
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+    BLOCK = "BLOCK"
+
+
+class Severity(str, enum.Enum):
+    INFO = "info"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class AgentName(str, enum.Enum):
+    TRIAGE = "TriageAgent"
+    SENTINEL = "GovernanceSentinel"
+    CONVERGENCE = "ConvergenceLoop"
+    COMPRESSOR = "ReviewDebtCompressor"
+    INLINE = "InlineThreadResolver"
+    BACKPRESSURE = "BackpressureGovernor"
+
+
+class RunStatus(str, enum.Enum):
+    OK = "ok"
+    ESCALATE = "escalate"
+    BLOCK = "block"
+    SKIP = "skip"
+
+
+# ---------------------------------------------------------------------------
+# Domain dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One concrete observation emitted by an agent."""
+
+    agent: AgentName
+    severity: Severity
+    message: str
+    path: str | None = None
+    line: int | None = None
+    rule_id: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "agent": self.agent.value,
+            "severity": self.severity.value,
+            "message": self.message,
+            "path": self.path,
+            "line": self.line,
+            "rule_id": self.rule_id,
+        }
+
+
+@dataclass
+class ThreadCluster:
+    """A deduped group of review threads. Confidence is in [0.0, 1.0]."""
+
+    representative_id: str
+    member_ids: list[str]
+    summary: str
+    confidence: float
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "representative_id": self.representative_id,
+            "member_ids": list(self.member_ids),
+            "summary": self.summary,
+            "confidence": round(self.confidence, 3),
+        }
+
+
+@dataclass
+class ReviewThread:
+    """A single review-comment thread on a PR."""
+
+    thread_id: str
+    path: str | None
+    line: int | None
+    body: str
+    author: str
+    resolved: bool
+    outdated: bool
+
+    def tokens(self) -> set[str]:
+        return _tokenise(self.body)
+
+
+@dataclass
+class PRState:
+    """Normalised PR state shared across every agent.
+
+    Built once by GH.fetch_state() and never mutated.
+    """
+
+    number: int
+    repo: str
+    title: str
+    body: str
+    base_ref: str
+    head_ref: str
+    head_sha: str
+    author: str
+    is_draft: bool
+    mergeable: str  # MERGEABLE | CONFLICTING | UNKNOWN
+    additions: int
+    deletions: int
+    changed_files: list[str]
+    labels: list[str]
+    check_states: dict[str, str]  # check name -> conclusion
+    threads: list[ReviewThread]
+    age_days: float
+    created_at: str
+    updated_at: str
+
+    @property
+    def total_loc(self) -> int:
+        return self.additions + self.deletions
+
+    @property
+    def unresolved_threads(self) -> list[ReviewThread]:
+        return [t for t in self.threads if not t.resolved]
+
+    @property
+    def all_checks_green(self) -> bool:
+        if not self.check_states:
+            return False
+        return all(
+            v.upper() == "SUCCESS" for v in self.check_states.values()
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "number": self.number,
+            "repo": self.repo,
+            "title": self.title,
+            "body": self.body,
+            "base_ref": self.base_ref,
+            "head_ref": self.head_ref,
+            "head_sha": self.head_sha,
+            "author": self.author,
+            "is_draft": self.is_draft,
+            "mergeable": self.mergeable,
+            "additions": self.additions,
+            "deletions": self.deletions,
+            "changed_files": list(self.changed_files),
+            "labels": list(self.labels),
+            "check_states": dict(self.check_states),
+            "threads": [asdict(t) for t in self.threads],
+            "age_days": self.age_days,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass
+class AgentResult:
+    """Every agent returns one of these. Pure data."""
+
+    agent: AgentName
+    status: RunStatus
+    findings: list[Finding] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def worst_severity(self) -> Severity:
+        if not self.findings:
+            return Severity.INFO
+        order = [
+            Severity.INFO,
+            Severity.LOW,
+            Severity.MEDIUM,
+            Severity.HIGH,
+            Severity.CRITICAL,
+        ]
+        return max(self.findings, key=lambda f: order.index(f.severity)).severity
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "agent": self.agent.value,
+            "status": self.status.value,
+            "findings": [f.as_dict() for f in self.findings],
+            "metadata": dict(self.metadata),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Hash-chained memory store
+# ---------------------------------------------------------------------------
+
+
+def _canonical_json(payload: Any) -> str:
+    """Deterministic JSON for hashing. Sorted keys, no whitespace."""
+
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    )
+
+
+def _sha256(data: str) -> str:
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+
+GENESIS_HASH = "0" * 64
+
+
+@dataclass
+class MemoryEntry:
+    """One immutable record in the audit chain."""
+
+    seq: int
+    timestamp: float
+    prev_hash: str
+    payload: dict[str, Any]
+    this_hash: str
+
+    @staticmethod
+    def compute_hash(seq: int, prev_hash: str, payload: dict[str, Any]) -> str:
+        return _sha256(
+            f"{seq}|{prev_hash}|{_canonical_json(payload)}"
+        )
+
+    def is_valid(self) -> bool:
+        return self.this_hash == MemoryEntry.compute_hash(
+            self.seq, self.prev_hash, self.payload
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "seq": self.seq,
+            "timestamp": self.timestamp,
+            "prev_hash": self.prev_hash,
+            "payload": self.payload,
+            "this_hash": self.this_hash,
+        }
+
+
+class MemoryCorrupted(RuntimeError):
+    """Raised when the audit chain has been tampered with."""
+
+
+class RalphMemory:
+    """Append-only, hash-chained JSON store.
+
+    On disk this is a JSONL file at `path`. Each line is one
+    MemoryEntry serialised as JSON. The chain is verified on load
+    (lazy) and on every append (strict).
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._entries: list[MemoryEntry] = []
+        self._loaded = False
+
+    # ----- I/O ------------------------------------------------------------
+
+    def _load(self) -> None:
+        if self._loaded:
+            return
+        self._entries = []
+        if self.path.exists():
+            with self.path.open("r", encoding="utf-8") as fh:
+                for raw in fh:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    obj = json.loads(raw)
+                    entry = MemoryEntry(
+                        seq=obj["seq"],
+                        timestamp=obj["timestamp"],
+                        prev_hash=obj["prev_hash"],
+                        payload=obj["payload"],
+                        this_hash=obj["this_hash"],
+                    )
+                    self._entries.append(entry)
+        self._loaded = True
+
+    def _atomic_append(self, entry: MemoryEntry) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        line = _canonical_json(entry.as_dict()) + "\n"
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        if self.path.exists():
+            shutil.copyfile(self.path, tmp)
+        with tmp.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+        os.replace(tmp, self.path)
+
+    # ----- Public API -----------------------------------------------------
+
+    def append(self, payload: dict[str, Any]) -> MemoryEntry:
+        """Append a new entry, link it to the previous hash, persist."""
+
+        self._load()
+        prev_hash = (
+            self._entries[-1].this_hash if self._entries else GENESIS_HASH
+        )
+        seq = len(self._entries)
+        ts = time.time()
+        this_hash = MemoryEntry.compute_hash(seq, prev_hash, payload)
+        entry = MemoryEntry(
+            seq=seq,
+            timestamp=ts,
+            prev_hash=prev_hash,
+            payload=payload,
+            this_hash=this_hash,
+        )
+        self._atomic_append(entry)
+        self._entries.append(entry)
+        return entry
+
+    def entries(self) -> list[MemoryEntry]:
+        self._load()
+        return list(self._entries)
+
+    def find(
+        self, *, pr_number: int | None = None, agent: AgentName | None = None
+    ) -> Iterator[MemoryEntry]:
+        """Yield entries matching the given filters."""
+
+        self._load()
+        for entry in self._entries:
+            payload = entry.payload
+            if pr_number is not None and payload.get("pr") != pr_number:
+                continue
+            if agent is not None and payload.get("agent") != agent.value:
+                continue
+            yield entry
+
+    def count_convergence_attempts(self, pr_number: int) -> int:
+        """How many ConvergenceLoop runs has this PR already had?"""
+
+        return sum(
+            1
+            for _ in self.find(
+                pr_number=pr_number, agent=AgentName.CONVERGENCE
+            )
+        )
+
+    def last_risk_tier(self, pr_number: int) -> RiskTier | None:
+        for entry in reversed(list(self.find(pr_number=pr_number))):
+            payload = entry.payload
+            if payload.get("agent") == AgentName.SENTINEL.value:
+                tier = payload.get("result", {}).get("metadata", {}).get(
+                    "tier"
+                )
+                if tier:
+                    return RiskTier(tier)
+        return None
+
+    def verify_chain(self) -> tuple[bool, str]:
+        """Return (is_valid, message). Re-walks the whole chain."""
+
+        self._load()
+        prev_hash = GENESIS_HASH
+        for entry in self._entries:
+            if entry.prev_hash != prev_hash:
+                return False, (
+                    f"prev_hash mismatch at seq={entry.seq}: "
+                    f"expected {prev_hash[:12]}, got {entry.prev_hash[:12]}"
+                )
+            recomputed = MemoryEntry.compute_hash(
+                entry.seq, entry.prev_hash, entry.payload
+            )
+            if recomputed != entry.this_hash:
+                return False, (
+                    f"this_hash mismatch at seq={entry.seq}: "
+                    f"expected {recomputed[:12]}, "
+                    f"got {entry.this_hash[:12]}"
+                )
+            prev_hash = entry.this_hash
+        return True, f"chain valid: {len(self._entries)} entries"
+
+
+# ---------------------------------------------------------------------------
+# Tokenisation (shared utility — agents are forbidden from importing each
+# other but may import shared helpers from this module)
+# ---------------------------------------------------------------------------
+
+
+_TOKEN_SPLIT = "".join(
+    chr(c) for c in range(256) if not (chr(c).isalnum() or chr(c) == "_")
+)
+
+
+def _tokenise(text: str) -> set[str]:
+    out: set[str] = set()
+    buf: list[str] = []
+    for ch in text.lower():
+        if ch.isalnum() or ch == "_":
+            buf.append(ch)
+        else:
+            if buf:
+                out.add("".join(buf))
+                buf = []
+    if buf:
+        out.add("".join(buf))
+    return {t for t in out if len(t) >= 3}
+
+
+# ---------------------------------------------------------------------------
+# gh CLI wrapper
+# ---------------------------------------------------------------------------
+
+
+class GHError(RuntimeError):
+    """Wraps a non-zero gh CLI exit."""
+
+
+class GH:
+    """Thin wrapper around the gh CLI.
+
+    Every method either reads (no side effects) or, when `execute=False`,
+    returns the command it WOULD have run. This lets the orchestrator
+    run in dry-run mode and audit every action.
+    """
+
+    def __init__(self, repo: str, execute: bool = False) -> None:
+        self.repo = repo
+        self.execute = execute
+
+    # ----- low-level -------------------------------------------------------
+
+    def _run(
+        self, args: list[str], *, capture: bool = True, mutating: bool = False
+    ) -> str:
+        if mutating and not self.execute:
+            return ""
+        cmd = ["gh", *args, "--repo", self.repo]
+        try:
+            out = subprocess.run(
+                cmd,
+                check=True,
+                capture_output=capture,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:  # pragma: no cover
+            raise GHError(f"gh failed: {cmd}\nstderr: {e.stderr}") from e
+        return out.stdout if capture else ""
+
+    def _json(self, args: list[str]) -> Any:
+        raw = self._run(args)
+        if not raw.strip():
+            return None
+        return json.loads(raw)
+
+    # ----- reads ----------------------------------------------------------
+
+    def list_open_prs(self) -> list[int]:
+        data = self._json(
+            [
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--limit",
+                "200",
+                "--json",
+                "number",
+            ]
+        )
+        return [p["number"] for p in (data or [])]
+
+    def fetch_state(self, pr_number: int) -> PRState:
+        fields = ",".join(
+            [
+                "number",
+                "title",
+                "body",
+                "baseRefName",
+                "headRefName",
+                "headRefOid",
+                "author",
+                "isDraft",
+                "mergeable",
+                "additions",
+                "deletions",
+                "files",
+                "labels",
+                "statusCheckRollup",
+                "reviewThreads",
+                "createdAt",
+                "updatedAt",
+            ]
+        )
+        data = self._json(
+            [
+                "pr",
+                "view",
+                str(pr_number),
+                "--json",
+                fields,
+            ]
+        )
+        if data is None:
+            raise GHError(f"PR #{pr_number} not found in {self.repo}")
+        return _parse_pr_state(self.repo, data)
+
+    # ----- writes (all mutating; respect execute flag) --------------------
+
+    def post_comment(self, pr_number: int, body: str) -> None:
+        self._run(
+            ["pr", "comment", str(pr_number), "--body", body],
+            capture=False,
+            mutating=True,
+        )
+
+    def reply_to_thread(
+        self, pr_number: int, thread_id: str, body: str
+    ) -> None:
+        # gh CLI does not support per-thread replies directly; fall back
+        # to a regular PR comment that references the thread.
+        self.post_comment(
+            pr_number,
+            f"_re: thread `{thread_id}`_\n\n{body}",
+        )
+
+    def add_label(self, pr_number: int, label: str) -> None:
+        self._run(
+            ["pr", "edit", str(pr_number), "--add-label", label],
+            capture=False,
+            mutating=True,
+        )
+
+    def remove_label(self, pr_number: int, label: str) -> None:
+        self._run(
+            ["pr", "edit", str(pr_number), "--remove-label", label],
+            capture=False,
+            mutating=True,
+        )
+
+    def squash_merge(self, pr_number: int) -> None:
+        self._run(
+            ["pr", "merge", str(pr_number), "--squash", "--auto"],
+            capture=False,
+            mutating=True,
+        )
+
+    def upsert_issue(
+        self, title: str, body: str, label: str = "ralph-backlog"
+    ) -> int:
+        """Create the backlog issue if missing, otherwise edit in place."""
+
+        data = self._json(
+            [
+                "issue",
+                "list",
+                "--label",
+                label,
+                "--state",
+                "open",
+                "--limit",
+                "5",
+                "--json",
+                "number,title",
+            ]
+        )
+        for issue in data or []:
+            if issue["title"] == title:
+                self._run(
+                    [
+                        "issue",
+                        "edit",
+                        str(issue["number"]),
+                        "--body",
+                        body,
+                    ],
+                    capture=False,
+                    mutating=True,
+                )
+                return int(issue["number"])
+        raw = self._run(
+            [
+                "issue",
+                "create",
+                "--title",
+                title,
+                "--body",
+                body,
+                "--label",
+                label,
+            ],
+            mutating=True,
+        )
+        # gh prints the URL on stdout; parse number off the end.
+        if raw and "/" in raw:
+            try:
+                return int(raw.rsplit("/", 1)[-1].strip())
+            except ValueError:
+                return -1
+        return -1
+
+
+def _parse_pr_state(repo: str, data: dict[str, Any]) -> PRState:
+    author = data.get("author") or {}
+    files = [f["path"] for f in data.get("files", [])]
+    labels = [lbl["name"] for lbl in data.get("labels", [])]
+    rollup = data.get("statusCheckRollup") or []
+    check_states: dict[str, str] = {}
+    for c in rollup:
+        name = c.get("name") or c.get("context") or "unknown"
+        conclusion = (
+            c.get("conclusion") or c.get("state") or "PENDING"
+        )
+        check_states[name] = conclusion
+    threads_raw = data.get("reviewThreads") or []
+    threads: list[ReviewThread] = []
+    for t in threads_raw:
+        comments = t.get("comments") or []
+        first = comments[0] if comments else {}
+        body = first.get("body", "")
+        author_login = (first.get("author") or {}).get("login", "?")
+        threads.append(
+            ReviewThread(
+                thread_id=t.get("id", ""),
+                path=t.get("path"),
+                line=t.get("line"),
+                body=body,
+                author=author_login,
+                resolved=bool(t.get("isResolved")),
+                outdated=bool(t.get("isOutdated")),
+            )
+        )
+    created_at = data.get("createdAt", "")
+    age_days = _age_days(created_at)
+    return PRState(
+        number=int(data["number"]),
+        repo=repo,
+        title=data.get("title", ""),
+        body=data.get("body", "") or "",
+        base_ref=data.get("baseRefName", "main"),
+        head_ref=data.get("headRefName", ""),
+        head_sha=data.get("headRefOid", ""),
+        author=author.get("login", "?"),
+        is_draft=bool(data.get("isDraft", False)),
+        mergeable=data.get("mergeable", "UNKNOWN"),
+        additions=int(data.get("additions", 0)),
+        deletions=int(data.get("deletions", 0)),
+        changed_files=files,
+        labels=labels,
+        check_states=check_states,
+        threads=threads,
+        age_days=age_days,
+        created_at=created_at,
+        updated_at=data.get("updatedAt", ""),
+    )
+
+
+def _age_days(iso_ts: str) -> float:
+    if not iso_ts:
+        return 0.0
+    # Best-effort parse — gh emits RFC3339.
+    try:
+        from datetime import datetime, timezone
+
+        ts = datetime.fromisoformat(iso_ts.replace("Z", "+00:00"))
+        delta = datetime.now(timezone.utc) - ts
+        return round(delta.total_seconds() / 86400.0, 2)
+    except (ValueError, TypeError):
+        return 0.0
+
+
+__all__ = [
+    "AgentName",
+    "AgentResult",
+    "Finding",
+    "GH",
+    "GHError",
+    "MemoryCorrupted",
+    "MemoryEntry",
+    "PRClass",
+    "PRState",
+    "RalphMemory",
+    "ReviewThread",
+    "RiskTier",
+    "RunStatus",
+    "Severity",
+    "ThreadCluster",
+    "_tokenise",
+]

--- a/.github/scripts/ralph_orchestrator.py
+++ b/.github/scripts/ralph_orchestrator.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""Ralph: pipeline orchestrator.
+
+Composes the six agents into one deterministic pass per PR:
+
+    Triage → Sentinel → Convergence → Compressor → Inline → Backpressure
+
+Then builds the SITREP markdown, upserts a singleton backlog issue,
+and (if --execute and all gates pass) squash-merges PRs that meet the
+auto-merge criteria. Returns exit code 1 if any BLOCK-tier finding
+appears, so CI fails closed on policy violations.
+
+Usage:
+    python ralph_orchestrator.py --repo OWNER/REPO
+    python ralph_orchestrator.py --repo OWNER/REPO --pr 42 67 --execute
+    python ralph_orchestrator.py --repo OWNER/REPO --verify-chain
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from ralph_agents import (
+    BackpressureGovernor,
+    ConvergenceLoop,
+    GovernanceSentinel,
+    InlineThreadResolver,
+    ReviewDebtCompressor,
+    TriageAgent,
+)
+from ralph_models import (
+    GH,
+    AgentName,
+    AgentResult,
+    Finding,
+    GHError,
+    PRState,
+    RalphMemory,
+    RiskTier,
+    RunStatus,
+    Severity,
+)
+
+
+DEFAULT_MEMORY_PATH = Path(".github/ralph-memory/memory.jsonl")
+BACKLOG_LABEL = "ralph-backlog"
+RALPH_LABEL_LOW = "ralph/low-risk"
+RALPH_LABEL_BLOCK = "ralph/blocked"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PipelineOutcome:
+    pr: int
+    state: PRState
+    results: list[AgentResult]
+    risk_tier: RiskTier
+    risk: float
+    auto_merged: bool
+    blocked: bool
+    sitrep: str
+
+
+def run_pipeline(
+    state: PRState, memory: RalphMemory
+) -> list[AgentResult]:
+    agents = [
+        TriageAgent(),
+        GovernanceSentinel(),
+        ConvergenceLoop(),
+        ReviewDebtCompressor(),
+        InlineThreadResolver(),
+        BackpressureGovernor(),
+    ]
+    results: list[AgentResult] = []
+    for agent in agents:
+        result = agent.run(state, memory)
+        memory.append(
+            {
+                "pr": state.number,
+                "head_sha": state.head_sha,
+                "agent": result.agent.value,
+                "result": result.as_dict(),
+            }
+        )
+        results.append(result)
+    return results
+
+
+def _risk_from_results(
+    results: list[AgentResult],
+) -> tuple[RiskTier, float]:
+    for r in results:
+        if r.agent is AgentName.SENTINEL:
+            tier_raw = r.metadata.get("tier")
+            risk_raw = r.metadata.get("risk", 0.0)
+            tier = (
+                RiskTier(tier_raw) if tier_raw else RiskTier.LOW
+            )
+            return tier, float(risk_raw)
+    return RiskTier.LOW, 0.0
+
+
+def _has_block(results: list[AgentResult]) -> bool:
+    for r in results:
+        if r.status is RunStatus.BLOCK:
+            return True
+        for f in r.findings:
+            if f.severity is Severity.CRITICAL:
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Auto-merge gate
+# ---------------------------------------------------------------------------
+
+
+def _can_auto_merge(
+    state: PRState, results: list[AgentResult], tier: RiskTier
+) -> tuple[bool, str]:
+    if state.is_draft:
+        return False, "PR is draft"
+    if state.mergeable.upper() != "MERGEABLE":
+        return False, f"mergeable={state.mergeable}"
+    if not state.all_checks_green:
+        return False, "not all checks are green"
+    if tier is not RiskTier.LOW:
+        return False, f"risk tier is {tier.value}"
+    if state.unresolved_threads:
+        return False, (
+            f"{len(state.unresolved_threads)} unresolved review threads"
+        )
+    if _has_block(results):
+        return False, "block-tier finding present"
+    # Any high-severity finding from any agent disqualifies.
+    for r in results:
+        for f in r.findings:
+            if f.severity in (Severity.HIGH, Severity.CRITICAL):
+                return False, (
+                    f"{r.agent.value} raised {f.severity.value} finding"
+                )
+    return True, "all gates passed"
+
+
+# ---------------------------------------------------------------------------
+# SITREP
+# ---------------------------------------------------------------------------
+
+
+def build_sitrep(
+    state: PRState,
+    results: list[AgentResult],
+    tier: RiskTier,
+    risk: float,
+    auto_merged: bool,
+    merge_reason: str,
+) -> str:
+    lines: list[str] = []
+    lines.append(f"# Ralph SITREP — PR #{state.number}")
+    lines.append("")
+    lines.append(
+        f"**{state.repo}** · head `{state.head_sha[:8]}` · "
+        f"age `{state.age_days:.1f}d` · LOC `+{state.additions}/"
+        f"-{state.deletions}` · threads `{len(state.unresolved_threads)}` "
+        f"unresolved"
+    )
+    lines.append("")
+    lines.append(
+        f"**Risk:** `{risk:.2f}` → tier **{tier.value}**"
+    )
+    lines.append("")
+
+    lines.append("## Pipeline")
+    lines.append("")
+    lines.append("| Stage | Status | Worst finding |")
+    lines.append("|---|---|---|")
+    for r in results:
+        worst = r.worst_severity().value if r.findings else "—"
+        lines.append(
+            f"| {r.agent.value} | {r.status.value} | {worst} |"
+        )
+    lines.append("")
+
+    findings = [f for r in results for f in r.findings]
+    if findings:
+        lines.append("## Findings")
+        lines.append("")
+        # Sort: CRITICAL > HIGH > MEDIUM > LOW > INFO
+        order = {
+            Severity.CRITICAL: 0,
+            Severity.HIGH: 1,
+            Severity.MEDIUM: 2,
+            Severity.LOW: 3,
+            Severity.INFO: 4,
+        }
+        for f in sorted(findings, key=lambda x: order[x.severity]):
+            loc = ""
+            if f.path:
+                loc = f" — `{f.path}`"
+                if f.line:
+                    loc = f" — `{f.path}:{f.line}`"
+            rule = f" `[{f.rule_id}]`" if f.rule_id else ""
+            lines.append(
+                f"- **{f.severity.value.upper()}** "
+                f"({f.agent.value}){rule}{loc}: {f.message}"
+            )
+        lines.append("")
+
+    lines.append("## Action")
+    lines.append("")
+    if auto_merged:
+        lines.append(
+            f"✅ Auto-merge dispatched (squash). Reason: {merge_reason}."
+        )
+    else:
+        lines.append(f"⏸ Held. Reason: {merge_reason}.")
+    lines.append("")
+    lines.append(
+        f"_Pipeline: Triage → Sentinel → Convergence → Compressor → "
+        f"Inline → Backpressure_"
+    )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Backlog issue
+# ---------------------------------------------------------------------------
+
+
+BACKLOG_TITLE = "Ralph: open PR backlog"
+
+
+def build_backlog_body(outcomes: list[PipelineOutcome]) -> str:
+    rows: list[str] = []
+    rows.append("# Open PR backlog")
+    rows.append("")
+    rows.append(
+        "Auto-managed by Ralph. Updated on every workflow run; "
+        "do not edit manually — edits will be overwritten."
+    )
+    rows.append("")
+    rows.append(
+        "| PR | Title | Tier | LOC | Threads | Age | Status |"
+    )
+    rows.append("|---:|---|---|---:|---:|---:|---|")
+    for o in sorted(outcomes, key=lambda x: x.pr):
+        status = (
+            "✅ merged"
+            if o.auto_merged
+            else ("🛑 BLOCKED" if o.blocked else "⏸ held")
+        )
+        title = o.state.title.replace("|", "\\|")[:60]
+        rows.append(
+            f"| #{o.pr} | {title} | {o.risk_tier.value} | "
+            f"{o.state.total_loc} | "
+            f"{len(o.state.unresolved_threads)} | "
+            f"{o.state.age_days:.1f}d | {status} |"
+        )
+    rows.append("")
+    rows.append("_Singleton issue; safe to close — Ralph will re-open._")
+    return "\n".join(rows)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="ralph_orchestrator",
+        description="Ralph PR-intelligence pipeline.",
+    )
+    p.add_argument(
+        "--repo",
+        required=True,
+        help="GitHub repo, e.g. owner/name.",
+    )
+    p.add_argument(
+        "--pr",
+        type=int,
+        nargs="*",
+        default=None,
+        help=(
+            "Specific PR number(s) to process. "
+            "Default: every open PR."
+        ),
+    )
+    p.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually invoke mutating gh commands. Default: dry-run.",
+    )
+    p.add_argument(
+        "--memory",
+        type=Path,
+        default=DEFAULT_MEMORY_PATH,
+        help=f"Memory file path. Default: {DEFAULT_MEMORY_PATH}",
+    )
+    p.add_argument(
+        "--verify-chain",
+        action="store_true",
+        help="Verify the audit chain and exit.",
+    )
+    p.add_argument(
+        "--sitrep-out",
+        type=Path,
+        default=None,
+        help=(
+            "If set, write the concatenated SITREPs to this file "
+            "(useful for CI step summaries)."
+        ),
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    memory = RalphMemory(args.memory)
+
+    if args.verify_chain:
+        ok, msg = memory.verify_chain()
+        sys.stdout.write(msg + "\n")
+        return 0 if ok else 2
+
+    gh = GH(args.repo, execute=args.execute)
+    pr_numbers = args.pr if args.pr is not None else gh.list_open_prs()
+    if not pr_numbers:
+        sys.stdout.write("No open PRs.\n")
+        return 0
+
+    outcomes: list[PipelineOutcome] = []
+    any_block = False
+    sitreps: list[str] = []
+
+    for pr in pr_numbers:
+        try:
+            state = gh.fetch_state(pr)
+        except GHError as e:
+            sys.stderr.write(f"skip #{pr}: {e}\n")
+            continue
+        results = run_pipeline(state, memory)
+        tier, risk = _risk_from_results(results)
+        blocked = _has_block(results)
+        can_merge, reason = _can_auto_merge(state, results, tier)
+        auto_merged = False
+        if can_merge:
+            try:
+                gh.squash_merge(state.number)
+                if args.execute:
+                    gh.add_label(state.number, RALPH_LABEL_LOW)
+                auto_merged = True
+                memory.append(
+                    {
+                        "pr": state.number,
+                        "head_sha": state.head_sha,
+                        "agent": "Orchestrator",
+                        "result": {
+                            "status": "auto-merged",
+                            "reason": reason,
+                        },
+                    }
+                )
+            except GHError as e:
+                reason = f"merge failed: {e}"
+        elif blocked and args.execute:
+            try:
+                gh.add_label(state.number, RALPH_LABEL_BLOCK)
+            except GHError:
+                pass
+        sitrep = build_sitrep(
+            state,
+            results,
+            tier,
+            risk,
+            auto_merged=auto_merged,
+            merge_reason=reason,
+        )
+        sitreps.append(sitrep)
+        sys.stdout.write(sitrep + "\n\n")
+        outcomes.append(
+            PipelineOutcome(
+                pr=state.number,
+                state=state,
+                results=results,
+                risk_tier=tier,
+                risk=risk,
+                auto_merged=auto_merged,
+                blocked=blocked,
+                sitrep=sitrep,
+            )
+        )
+        any_block = any_block or blocked
+
+    if outcomes:
+        body = build_backlog_body(outcomes)
+        try:
+            gh.upsert_issue(BACKLOG_TITLE, body, label=BACKLOG_LABEL)
+        except GHError as e:
+            sys.stderr.write(f"backlog upsert failed: {e}\n")
+
+    if args.sitrep_out:
+        args.sitrep_out.parent.mkdir(parents=True, exist_ok=True)
+        args.sitrep_out.write_text(
+            "\n\n---\n\n".join(sitreps), encoding="utf-8"
+        )
+
+    ok, msg = memory.verify_chain()
+    if not ok:
+        sys.stderr.write(f"AUDIT CHAIN BROKEN: {msg}\n")
+        return 2
+
+    return 1 if any_block else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ralph.yml
+++ b/.github/workflows/ralph.yml
@@ -1,0 +1,131 @@
+name: Ralph
+
+# Three triggers:
+#   1. Scheduled — weekdays 08:00 AEST (= 22:00 UTC the prior day).
+#   2. pull_request — single-PR mode on opened/synchronize/reopened.
+#   3. workflow_dispatch — manual ad-hoc runs.
+#
+# The governance-gate job is the required status check that blocks
+# merges when Ralph reports BLOCK-tier risk for the PR head.
+
+on:
+  schedule:
+    # 0 22 * * 0-4 → Sun-Thu 22:00 UTC → Mon-Fri 08:00 AEST (UTC+10).
+    - cron: "0 22 * * 0-4"
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Specific PR number to run against (optional)."
+        required: false
+        type: string
+      execute:
+        description: "Apply mutating actions (post comments, merge, label)."
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: ralph-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  checks: write
+
+jobs:
+  ralph:
+    name: Ralph pipeline
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RALPH_MEMORY: .github/ralph-memory/memory.jsonl
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Restore memory cache
+        id: cache-memory
+        uses: actions/cache@v4
+        with:
+          path: .github/ralph-memory
+          key: ralph-memory-${{ github.repository_id }}-v1
+          restore-keys: |
+            ralph-memory-${{ github.repository_id }}-
+
+      - name: Verify audit chain (pre-run)
+        run: |
+          python .github/scripts/ralph_orchestrator.py \
+            --repo "${{ github.repository }}" \
+            --memory "$RALPH_MEMORY" \
+            --verify-chain
+
+      - name: Choose PRs to process
+        id: select
+        run: |
+          set -euo pipefail
+          MODE="${{ github.event_name }}"
+          if [ "$MODE" = "pull_request" ]; then
+            echo "pr=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "execute=false" >> "$GITHUB_OUTPUT"
+          elif [ "$MODE" = "workflow_dispatch" ]; then
+            echo "pr=${{ github.event.inputs.pr }}" >> "$GITHUB_OUTPUT"
+            echo "execute=${{ github.event.inputs.execute }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr=" >> "$GITHUB_OUTPUT"
+            echo "execute=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Ralph
+        id: ralph
+        run: |
+          set -euo pipefail
+          ARGS=(--repo "${{ github.repository }}" \
+                --memory "$RALPH_MEMORY" \
+                --sitrep-out "$GITHUB_STEP_SUMMARY")
+          if [ -n "${{ steps.select.outputs.pr }}" ]; then
+            ARGS+=(--pr "${{ steps.select.outputs.pr }}")
+          fi
+          if [ "${{ steps.select.outputs.execute }}" = "true" ]; then
+            ARGS+=(--execute)
+          fi
+          python .github/scripts/ralph_orchestrator.py "${ARGS[@]}"
+
+      - name: Save memory cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: .github/ralph-memory
+          key: ralph-memory-${{ github.repository_id }}-v1-${{ github.run_id }}
+
+      - name: Upload memory artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ralph-memory-${{ github.run_id }}
+          path: .github/ralph-memory/memory.jsonl
+          if-no-files-found: warn
+          retention-days: 30
+
+  governance-gate:
+    # Required status check. Inherits ralph's exit code: a BLOCK-tier
+    # finding causes the ralph job to exit 1, which fails this job too.
+    name: governance-gate
+    runs-on: ubuntu-latest
+    needs: [ralph]
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Gate result
+        run: |
+          echo "Ralph pipeline completed without BLOCK-tier findings."


### PR DESCRIPTION
Two new SKILL.md packages under .claude/skills and .agents/skills:

- spec-drift-hunter: compares stated intent (README, contracts,
  workflows, tests, issue intent, PR description) against realized
  behavior and emits a severity-sorted drift report with file:line
  citations. Read-only; diagnoses without patching.

- reviewer-load-balancer: routes PR review work to the appropriate
  reviewers (CodeRabbit, Gemini, Semgrep, CodeQL, Claude/Codex, human)
  based on changed-file class, diff size, and security sensitivity.
  Skips AI review on binary/generated/unsupported files; reserves human
  review for workflow/auth/contract changes.

Each skill ships with a .claude/ manifest plus a .agents/ variant whose
sub-agent definitions split the loop into extract / verify / report
(drift hunter) and classify / route / dispatch (load balancer) stages.

https://claude.ai/code/session_01Ct8cCVYMWXxG6jHduPsX7q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specifications for agent-based code review routing, including file classification, reviewer assignment, and execution workflows
  * Added specifications for specification drift detection across repository artifacts, claims extraction, and automated verification reporting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/canstralian/prompt-crafting/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->