### PR TITLE
Stage PR Necromancer tool for copy to bounty-ops-mcp

### DIFF
--- a/tools/pr-necromancer/.github/workflows/pr_necromancer.yml
+++ b/tools/pr-necromancer/.github/workflows/pr_necromancer.yml
@@ -1,0 +1,107 @@
+name: PR Necromancer
+
+on:
+  schedule:
+    # Weekly Monday 09:00 AEST (UTC+10) = Sunday 23:00 UTC
+    - cron: "0 23 * * 0"
+  workflow_dispatch:
+    inputs:
+      pr_numbers:
+        description: "Space-separated PR numbers (empty = all open)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Print plan only, no writes"
+        type: boolean
+        required: false
+        default: true
+      execute:
+        description: "Apply dispositions (comment / close / tag)"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  checks: read
+
+concurrency:
+  group: pr-necromancer-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  necromance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests scikit-learn
+
+      - name: Determine flags
+        id: flags
+        run: |
+          pr_args=""
+          if [ -n "${{ github.event.inputs.pr_numbers }}" ]; then
+            pr_args="--pr ${{ github.event.inputs.pr_numbers }}"
+          fi
+          mode=""
+          if [ "${{ github.event.inputs.execute }}" = "true" ] && [ "${{ github.event.inputs.dry_run }}" != "true" ]; then
+            mode="--execute"
+          else
+            mode="--dry-run"
+          fi
+          echo "pr_args=$pr_args" >> "$GITHUB_OUTPUT"
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
+      - name: Run necromancer
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          python tools/pr-necromancer/pr_necromancer.py \
+            --repo "$GITHUB_REPOSITORY" \
+            ${{ steps.flags.outputs.pr_args }} \
+            ${{ steps.flags.outputs.mode }} \
+            --json-out necromancer-report.json
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: necromancer-report
+          path: necromancer-report.json
+          retention-days: 30
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## PR Necromancer summary"
+            echo ""
+            if [ -f necromancer-report.json ]; then
+              python -c "
+          import json
+          with open('necromancer-report.json') as f:
+              data = json.load(f)
+          print('| PR | Score | Disposition | Override |')
+          print('|---|---|---|---|')
+          for r in data:
+              print(f\"| #{r['pr_number']} | {r['score']:.3f} | {r['disposition']} | {r.get('override') or '—'} |\")
+          "
+            else
+              echo "No report produced."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/tools/pr-necromancer/drift_scorer.py
+++ b/tools/pr-necromancer/drift_scorer.py
@@ -1,0 +1,263 @@
+"""Drift scorer for stale pull requests.
+
+Computes a composite drift score in [0.0, 1.0] across seven signals.
+Higher score = more drift = stronger case to close/archive.
+
+Signal weights (sum to 1.0):
+    file_relevance      0.25  files in PR no longer exist on main
+    logic_absorption    0.20  PR diff vs. post-open commits on main (TF-IDF cosine)
+    conflict_density    0.20  mergeable state + touched-file count
+    semantic_distance   0.15  vocabulary drift PR <-> recent main commits
+    package_delta       0.10  added/removed packages now divergent
+    ruleset_staleness   0.05  security/config files in PR since updated on main
+    age_penalty         0.05  exponential decay; sharp at 30d, plateau at 120d
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Optional
+
+try:
+    from sklearn.feature_extraction.text import TfidfVectorizer
+    from sklearn.metrics.pairwise import cosine_similarity
+
+    _HAS_SKLEARN = True
+except ImportError:  # pragma: no cover
+    _HAS_SKLEARN = False
+
+
+SIGNAL_WEIGHTS: dict[str, float] = {
+    "file_relevance": 0.25,
+    "logic_absorption": 0.20,
+    "conflict_density": 0.20,
+    "semantic_distance": 0.15,
+    "package_delta": 0.10,
+    "ruleset_staleness": 0.05,
+    "age_penalty": 0.05,
+}
+
+SECURITY_PATHS = (
+    ".github/workflows/",
+    "security/",
+    "auth/",
+    "SECURITY.md",
+    "dependabot.yml",
+    "CODEOWNERS",
+)
+
+PACKAGE_FILES = (
+    "requirements.txt",
+    "requirements.in",
+    "pyproject.toml",
+    "Pipfile",
+    "package.json",
+    "Cargo.toml",
+    "go.mod",
+)
+
+
+@dataclass
+class PRSnapshot:
+    """Everything needed to score a PR. Caller assembles via the GitHub API."""
+
+    number: int
+    title: str
+    body: str
+    labels: list[str]
+    created_at: datetime
+    mergeable: Optional[bool]
+    mergeable_state: str  # "clean" | "dirty" | "blocked" | "behind" | "unknown" | ...
+    ci_passing: Optional[bool]
+    changed_files: list[str]
+    diff_text: str
+    added_packages: list[str]
+    removed_packages: list[str]
+    main_files: set[str]
+    post_open_commit_messages: list[str]
+    post_open_commit_diff: str
+    recent_main_commit_messages: list[str]
+    current_requirements_packages: set[str]
+    main_security_paths_changed_since: set[str]
+
+
+@dataclass
+class DriftReport:
+    pr_number: int
+    score: float
+    disposition: str
+    signals: dict[str, float] = field(default_factory=dict)
+    reasons: list[str] = field(default_factory=list)
+    override: Optional[str] = None
+
+
+def _clamp(x: float) -> float:
+    if x < 0.0:
+        return 0.0
+    if x > 1.0:
+        return 1.0
+    return x
+
+
+def _tokenize(text: str) -> list[str]:
+    return re.findall(r"[A-Za-z_][A-Za-z0-9_]{2,}", text.lower())
+
+
+def _jaccard(a: Iterable[str], b: Iterable[str]) -> float:
+    sa, sb = set(a), set(b)
+    if not sa and not sb:
+        return 0.0
+    union = sa | sb
+    if not union:
+        return 0.0
+    return len(sa & sb) / len(union)
+
+
+def _tfidf_cosine(a: str, b: str) -> float:
+    """TF-IDF cosine between two texts. Falls back to Jaccard if sklearn missing."""
+    if not a.strip() or not b.strip():
+        return 0.0
+    if _HAS_SKLEARN:
+        vec = TfidfVectorizer(stop_words="english", max_features=2000)
+        try:
+            matrix = vec.fit_transform([a, b])
+        except ValueError:
+            return 0.0
+        sim = cosine_similarity(matrix[0:1], matrix[1:2])[0][0]
+        return float(sim)
+    return _jaccard(_tokenize(a), _tokenize(b))
+
+
+def score_file_relevance(snap: PRSnapshot) -> float:
+    if not snap.changed_files:
+        return 0.0
+    missing = sum(1 for f in snap.changed_files if f not in snap.main_files)
+    return _clamp(missing / len(snap.changed_files))
+
+
+def score_logic_absorption(snap: PRSnapshot) -> float:
+    return _clamp(_tfidf_cosine(snap.diff_text, snap.post_open_commit_diff))
+
+
+def score_conflict_density(snap: PRSnapshot) -> float:
+    state_penalty = {
+        "clean": 0.0,
+        "unstable": 0.25,
+        "behind": 0.45,
+        "blocked": 0.55,
+        "draft": 0.30,
+        "dirty": 0.85,
+        "unknown": 0.40,
+    }.get(snap.mergeable_state, 0.40)
+
+    if snap.mergeable is False:
+        state_penalty = max(state_penalty, 0.85)
+
+    file_pressure = _clamp(len(snap.changed_files) / 40.0)
+    return _clamp(0.7 * state_penalty + 0.3 * file_pressure)
+
+
+def score_semantic_distance(snap: PRSnapshot) -> float:
+    pr_text = f"{snap.title}\n{snap.body}"
+    main_text = "\n".join(snap.recent_main_commit_messages)
+    similarity = _tfidf_cosine(pr_text, main_text)
+    return _clamp(1.0 - similarity)
+
+
+def score_package_delta(snap: PRSnapshot) -> float:
+    pkgs = set(snap.added_packages) | set(snap.removed_packages)
+    if not pkgs:
+        return 0.0
+    diverged = 0
+    for pkg in pkgs:
+        in_current = pkg in snap.current_requirements_packages
+        if pkg in snap.added_packages and in_current:
+            diverged += 1
+        if pkg in snap.removed_packages and not in_current:
+            diverged += 1
+    return _clamp(diverged / len(pkgs))
+
+
+def score_ruleset_staleness(snap: PRSnapshot) -> float:
+    pr_security_files = {
+        f for f in snap.changed_files if any(f.startswith(p) or f == p for p in SECURITY_PATHS)
+    }
+    if not pr_security_files:
+        return 0.0
+    overlap = pr_security_files & snap.main_security_paths_changed_since
+    return _clamp(len(overlap) / len(pr_security_files))
+
+
+def score_age_penalty(snap: PRSnapshot, now: Optional[datetime] = None) -> float:
+    now = now or datetime.now(timezone.utc)
+    age_days = max(0.0, (now - snap.created_at).total_seconds() / 86400.0)
+    return _clamp(1.0 - math.exp(-age_days / 60.0))
+
+
+SIGNAL_FUNCS = {
+    "file_relevance": score_file_relevance,
+    "logic_absorption": score_logic_absorption,
+    "conflict_density": score_conflict_density,
+    "semantic_distance": score_semantic_distance,
+    "package_delta": score_package_delta,
+    "ruleset_staleness": score_ruleset_staleness,
+    "age_penalty": score_age_penalty,
+}
+
+
+def disposition_for(score: float) -> str:
+    if score < 0.20:
+        return "merge"
+    if score < 0.40:
+        return "revive"
+    if score < 0.60:
+        return "cherry-pick"
+    if score < 0.80:
+        return "archive"
+    return "close"
+
+
+def score_pr(snap: PRSnapshot, now: Optional[datetime] = None) -> DriftReport:
+    signals: dict[str, float] = {}
+    for name, fn in SIGNAL_FUNCS.items():
+        signals[name] = fn(snap, now) if name == "age_penalty" else fn(snap)
+
+    composite = sum(signals[name] * SIGNAL_WEIGHTS[name] for name in SIGNAL_WEIGHTS)
+    composite = _clamp(composite)
+    disposition = disposition_for(composite)
+
+    override: Optional[str] = None
+    reasons: list[str] = []
+
+    is_security = any(label.lower() in {"security", "auth", "vuln"} for label in snap.labels)
+    if is_security and composite > 0.55:
+        override = "security PR with drift > 0.55"
+        disposition = "close"
+        reasons.append("Security-tagged PR past the 0.55 drift bar — close, don't cherry-pick.")
+
+    if (
+        override is None
+        and snap.ci_passing is True
+        and snap.mergeable is True
+        and snap.mergeable_state == "clean"
+        and composite < 0.35
+    ):
+        override = "CI green + clean merge + drift < 0.35"
+        disposition = "merge"
+        reasons.append("Green CI on a clean merge under the 0.35 drift bar — merge.")
+
+    for name, value in signals.items():
+        if value >= 0.5:
+            reasons.append(f"{name}={value:.2f} (weight {SIGNAL_WEIGHTS[name]:.2f})")
+
+    return DriftReport(
+        pr_number=snap.number,
+        score=round(composite, 3),
+        disposition=disposition,
+        signals={k: round(v, 3) for k, v in signals.items()},
+        reasons=reasons,
+        override=override,
+    )

--- a/tools/pr-necromancer/pr_necromancer.py
+++ b/tools/pr-necromancer/pr_necromancer.py
@@ -1,0 +1,454 @@
+"""PR Necromancer — score stale PRs and dispose of them.
+
+Usage:
+    python pr_necromancer.py --repo owner/name [--pr 42 67] [--execute] [--dry-run]
+
+Environment:
+    GITHUB_TOKEN     required, repo + workflow scopes
+    GITHUB_REPOSITORY optional fallback for --repo
+
+Dispositions:
+    merge        leave alone, ready to land
+    revive       rebase onto main, re-trigger CI
+    cherry-pick  comment with commit list to extract, then close
+    archive      close + create archive tag `archive/pr-<n>`
+    close        close as obsolete
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+import requests
+
+from drift_scorer import SECURITY_PATHS, PRSnapshot, score_pr
+
+GITHUB_API = "https://api.github.com"
+RECENT_MAIN_WINDOW_DAYS = 30
+USER_AGENT = "pr-necromancer/1.0"
+
+
+class GitHubClient:
+    def __init__(self, token: str, repo: str) -> None:
+        if "/" not in repo:
+            raise ValueError(f"repo must be 'owner/name', got: {repo}")
+        self.repo = repo
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": USER_AGENT,
+            }
+        )
+
+    def _get(self, path: str, **params: Any) -> Any:
+        r = self.session.get(f"{GITHUB_API}{path}", params=params, timeout=30)
+        r.raise_for_status()
+        return r.json()
+
+    def _get_text(self, path: str, accept: str) -> str:
+        r = self.session.get(
+            f"{GITHUB_API}{path}",
+            headers={"Accept": accept},
+            timeout=30,
+        )
+        r.raise_for_status()
+        return r.text
+
+    def list_open_prs(self) -> list[dict[str, Any]]:
+        prs: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            batch = self._get(
+                f"/repos/{self.repo}/pulls",
+                state="open",
+                per_page=100,
+                page=page,
+            )
+            if not batch:
+                break
+            prs.extend(batch)
+            if len(batch) < 100:
+                break
+            page += 1
+        return prs
+
+    def get_pr(self, number: int) -> dict[str, Any]:
+        return self._get(f"/repos/{self.repo}/pulls/{number}")
+
+    def get_pr_files(self, number: int) -> list[dict[str, Any]]:
+        files: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            batch = self._get(
+                f"/repos/{self.repo}/pulls/{number}/files",
+                per_page=100,
+                page=page,
+            )
+            if not batch:
+                break
+            files.extend(batch)
+            if len(batch) < 100:
+                break
+            page += 1
+        return files
+
+    def get_pr_diff(self, number: int) -> str:
+        return self._get_text(
+            f"/repos/{self.repo}/pulls/{number}",
+            accept="application/vnd.github.v3.diff",
+        )
+
+    def get_pr_checks(self, sha: str) -> Optional[bool]:
+        data = self._get(f"/repos/{self.repo}/commits/{sha}/check-runs")
+        runs = data.get("check_runs") or []
+        if not runs:
+            return None
+        for run in runs:
+            if run.get("status") != "completed":
+                return None
+            if run.get("conclusion") not in {"success", "skipped", "neutral"}:
+                return False
+        return True
+
+    def list_main_files(self, branch: str = "main") -> set[str]:
+        try:
+            tree = self._get(
+                f"/repos/{self.repo}/git/trees/{branch}",
+                recursive=1,
+            )
+        except requests.HTTPError:
+            tree = self._get(
+                f"/repos/{self.repo}/git/trees/master",
+                recursive=1,
+            )
+        return {item["path"] for item in tree.get("tree", []) if item.get("type") == "blob"}
+
+    def list_commits_since(self, since: datetime, branch: str = "main") -> list[dict[str, Any]]:
+        commits: list[dict[str, Any]] = []
+        page = 1
+        params = {"sha": branch, "since": since.isoformat(), "per_page": 100}
+        while True:
+            try:
+                batch = self._get(f"/repos/{self.repo}/commits", page=page, **params)
+            except requests.HTTPError:
+                params["sha"] = "master"
+                batch = self._get(f"/repos/{self.repo}/commits", page=page, **params)
+            if not batch:
+                break
+            commits.extend(batch)
+            if len(batch) < 100:
+                break
+            page += 1
+        return commits
+
+    def get_commit_files(self, sha: str) -> list[str]:
+        data = self._get(f"/repos/{self.repo}/commits/{sha}")
+        return [f["filename"] for f in data.get("files", [])]
+
+    def get_file_at_main(self, path: str, branch: str = "main") -> Optional[str]:
+        try:
+            data = self._get(f"/repos/{self.repo}/contents/{path}", ref=branch)
+        except requests.HTTPError:
+            try:
+                data = self._get(f"/repos/{self.repo}/contents/{path}", ref="master")
+            except requests.HTTPError:
+                return None
+        import base64
+
+        if isinstance(data, list):
+            return None
+        content = data.get("content", "")
+        encoding = data.get("encoding", "base64")
+        if encoding == "base64":
+            try:
+                return base64.b64decode(content).decode("utf-8", errors="replace")
+            except Exception:
+                return None
+        return content
+
+    def comment(self, number: int, body: str) -> None:
+        r = self.session.post(
+            f"{GITHUB_API}/repos/{self.repo}/issues/{number}/comments",
+            json={"body": body},
+            timeout=30,
+        )
+        r.raise_for_status()
+
+    def close_pr(self, number: int) -> None:
+        r = self.session.patch(
+            f"{GITHUB_API}/repos/{self.repo}/pulls/{number}",
+            json={"state": "closed"},
+            timeout=30,
+        )
+        r.raise_for_status()
+
+    def create_tag(self, name: str, sha: str) -> None:
+        r = self.session.post(
+            f"{GITHUB_API}/repos/{self.repo}/git/refs",
+            json={"ref": f"refs/tags/{name}", "sha": sha},
+            timeout=30,
+        )
+        if r.status_code == 422:
+            return
+        r.raise_for_status()
+
+
+def parse_packages(content: Optional[str], path: str) -> set[str]:
+    if not content:
+        return set()
+    pkgs: set[str] = set()
+    if path.endswith(("requirements.txt", "requirements.in")):
+        for line in content.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            name = line.split("==")[0].split(">=")[0].split("<=")[0].split("~=")[0]
+            name = name.split(";")[0].split("[")[0].strip()
+            if name:
+                pkgs.add(name.lower())
+    elif path == "package.json":
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError:
+            return pkgs
+        for section in ("dependencies", "devDependencies", "peerDependencies"):
+            for name in (data.get(section) or {}):
+                pkgs.add(name.lower())
+    return pkgs
+
+
+def diff_packages(pr_file: dict[str, Any]) -> tuple[list[str], list[str]]:
+    """Parse a unified patch for added/removed package lines."""
+    added: list[str] = []
+    removed: list[str] = []
+    patch = pr_file.get("patch") or ""
+    for line in patch.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            name = _pkg_name_from_line(line[1:])
+            if name:
+                added.append(name)
+        elif line.startswith("-") and not line.startswith("---"):
+            name = _pkg_name_from_line(line[1:])
+            if name:
+                removed.append(name)
+    return added, removed
+
+
+def _pkg_name_from_line(line: str) -> Optional[str]:
+    line = line.strip()
+    if not line or line.startswith("#"):
+        return None
+    name = line.split("==")[0].split(">=")[0].split("<=")[0].split("~=")[0]
+    name = name.split(":")[0].split('"')[0].split("'")[0]
+    name = name.strip().strip(",").strip()
+    if not name or any(c in name for c in (" ", "{", "}", "[", "]")):
+        return None
+    return name.lower()
+
+
+def build_snapshot(gh: GitHubClient, number: int, main_files: set[str],
+                   recent_commit_messages: list[str], post_open_diff: str,
+                   security_paths_changed: set[str]) -> PRSnapshot:
+    pr = gh.get_pr(number)
+    files = gh.get_pr_files(number)
+    diff_text = gh.get_pr_diff(number)
+    head_sha = pr["head"]["sha"]
+    ci = gh.get_pr_checks(head_sha)
+
+    added_pkgs: list[str] = []
+    removed_pkgs: list[str] = []
+    for f in files:
+        if f["filename"].endswith(PACKAGE_FILES_SUFFIX) or f["filename"] in PACKAGE_FILE_NAMES:
+            a, r = diff_packages(f)
+            added_pkgs.extend(a)
+            removed_pkgs.extend(r)
+
+    current_pkgs: set[str] = set()
+    for pkg_path in PACKAGE_FILE_NAMES:
+        content = gh.get_file_at_main(pkg_path)
+        current_pkgs |= parse_packages(content, pkg_path)
+
+    created_at = datetime.fromisoformat(pr["created_at"].replace("Z", "+00:00"))
+
+    return PRSnapshot(
+        number=number,
+        title=pr.get("title") or "",
+        body=pr.get("body") or "",
+        labels=[lbl["name"] for lbl in pr.get("labels", [])],
+        created_at=created_at,
+        mergeable=pr.get("mergeable"),
+        mergeable_state=pr.get("mergeable_state") or "unknown",
+        ci_passing=ci,
+        changed_files=[f["filename"] for f in files],
+        diff_text=diff_text,
+        added_packages=added_pkgs,
+        removed_packages=removed_pkgs,
+        main_files=main_files,
+        post_open_commit_messages=[],
+        post_open_commit_diff=post_open_diff,
+        recent_main_commit_messages=recent_commit_messages,
+        current_requirements_packages=current_pkgs,
+        main_security_paths_changed_since=security_paths_changed,
+    )
+
+
+PACKAGE_FILE_NAMES = (
+    "requirements.txt",
+    "requirements.in",
+    "pyproject.toml",
+    "Pipfile",
+    "package.json",
+    "Cargo.toml",
+    "go.mod",
+)
+PACKAGE_FILES_SUFFIX = tuple(f"/{n}" for n in PACKAGE_FILE_NAMES)
+
+
+def collect_main_context(gh: GitHubClient, oldest_pr_created: datetime) -> tuple[
+    set[str], list[str], str, set[str]
+]:
+    main_files = gh.list_main_files()
+    recent_cut = datetime.now(timezone.utc) - timedelta(days=RECENT_MAIN_WINDOW_DAYS)
+    recent_commits = gh.list_commits_since(recent_cut)
+    recent_msgs = [c["commit"]["message"] for c in recent_commits]
+
+    post_open_commits = gh.list_commits_since(oldest_pr_created)
+    post_open_diff_parts: list[str] = []
+    security_paths: set[str] = set()
+    for c in post_open_commits[:50]:
+        post_open_diff_parts.append(c["commit"]["message"])
+        try:
+            for f in gh.get_commit_files(c["sha"]):
+                if any(f.startswith(p) or f == p for p in SECURITY_PATHS):
+                    security_paths.add(f)
+        except requests.HTTPError:
+            continue
+
+    return main_files, recent_msgs, "\n".join(post_open_diff_parts), security_paths
+
+
+def render_comment(report: Any) -> str:
+    lines = [
+        "## PR Necromancer report",
+        "",
+        f"**Drift score:** `{report.score:.3f}`",
+        f"**Disposition:** `{report.disposition}`",
+    ]
+    if report.override:
+        lines.append(f"**Override applied:** {report.override}")
+    lines.append("")
+    lines.append("### Signals")
+    lines.append("")
+    lines.append("| Signal | Value |")
+    lines.append("|---|---|")
+    for k, v in report.signals.items():
+        lines.append(f"| {k} | {v:.3f} |")
+    if report.reasons:
+        lines.append("")
+        lines.append("### Reasons")
+        for r in report.reasons:
+            lines.append(f"- {r}")
+    return "\n".join(lines)
+
+
+def execute_disposition(gh: GitHubClient, pr: dict[str, Any], report: Any) -> None:
+    number = pr["number"]
+    sha = pr["head"]["sha"]
+    body = render_comment(report)
+    gh.comment(number, body)
+
+    if report.disposition == "merge":
+        return
+    if report.disposition == "revive":
+        gh.comment(number, "@necromancer-revive: rebase + re-run CI")
+        return
+    if report.disposition == "cherry-pick":
+        gh.comment(
+            number,
+            "Closing in favour of cherry-picking specific commits. "
+            "List the SHAs you want kept in a follow-up issue.",
+        )
+        gh.close_pr(number)
+        return
+    if report.disposition == "archive":
+        gh.create_tag(f"archive/pr-{number}", sha)
+        gh.close_pr(number)
+        return
+    if report.disposition == "close":
+        gh.close_pr(number)
+        return
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="PR Necromancer")
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--pr", nargs="*", type=int, default=None,
+                        help="Specific PR numbers; default = all open PRs")
+    parser.add_argument("--execute", action="store_true",
+                        help="Apply the disposition (comment / close / tag)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print plan only, no API writes")
+    parser.add_argument("--json-out", default=None, help="Write report JSON to path")
+    args = parser.parse_args()
+
+    if not args.repo:
+        print("error: --repo or GITHUB_REPOSITORY required", file=sys.stderr)
+        return 2
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        print("error: GITHUB_TOKEN required", file=sys.stderr)
+        return 2
+
+    gh = GitHubClient(token, args.repo)
+
+    if args.pr:
+        prs = [gh.get_pr(n) for n in args.pr]
+    else:
+        prs = gh.list_open_prs()
+
+    if not prs:
+        print("No open PRs to evaluate.")
+        return 0
+
+    oldest = min(datetime.fromisoformat(p["created_at"].replace("Z", "+00:00")) for p in prs)
+    main_files, recent_msgs, post_open_diff, security_changed = collect_main_context(gh, oldest)
+
+    reports = []
+    for pr in prs:
+        snap = build_snapshot(
+            gh,
+            pr["number"],
+            main_files,
+            recent_msgs,
+            post_open_diff,
+            security_changed,
+        )
+        report = score_pr(snap)
+        reports.append({"pr": pr["number"], **asdict(report)})
+
+        line = f"PR #{pr['number']}: drift={report.score:.3f} → {report.disposition}"
+        if report.override:
+            line += f"  [override: {report.override}]"
+        print(line)
+
+        if args.execute and not args.dry_run:
+            execute_disposition(gh, pr, report)
+
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as f:
+            json.dump(reports, f, indent=2, default=str)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/pr-necromancer/pr_necromancer.py
+++ b/tools/pr-necromancer/pr_necromancer.py
@@ -248,7 +248,7 @@ def _pkg_name_from_line(line: str) -> Optional[str]:
     if not line or line.startswith("#"):
         return None
     name = line.split("==")[0].split(">=")[0].split("<=")[0].split("~=")[0]
-    name = name.split(":")[0].split('"')[0].split("'")[0]
+    name = name.split(":")[0].strip().strip('"').strip("'")
     name = name.strip().strip(",").strip()
     if not name or any(c in name for c in (" ", "{", "}", "[", "]")):
         return None


### PR DESCRIPTION
## Summary

Stages three files under `tools/pr-necromancer/` for copy to `canstralian/bounty-ops-mcp`. Not wired into the prompt-crafting app — pure delivery directory.

- `drift_scorer.py` — 7-signal composite scorer (file_relevance 0.25, logic_absorption 0.20, conflict_density 0.20, semantic_distance 0.15, package_delta 0.10, ruleset_staleness 0.05, age_penalty 0.05). Age penalty `1 - e^(-age/60)`. Disposition bands: merge / revive / cherry-pick / archive / close at 0.20 / 0.40 / 0.60 / 0.80. Two hard overrides: green CI + clean merge + drift < 0.35 → merge; security label + drift > 0.55 → close. Optional `scikit-learn` import with a Jaccard fallback if unavailable.
- `pr_necromancer.py` — GitHub orchestrator. Builds a `PRSnapshot` per PR (files, diff, packages, checks, main tree, post-open commits), scores it, and applies the disposition: comments the report, then for archive creates `archive/pr-<n>` tag + closes; for cherry-pick comments and closes; for close just closes.
- `.github/workflows/pr_necromancer.yml` — weekly Monday 09:00 AEST (= Sunday 23:00 UTC) + `workflow_dispatch` with `pr_numbers`, `dry_run`, `execute` inputs. Uploads `necromancer-report.json` as an artifact and renders a per-PR job summary table.

Validated the scorer end-to-end on two synthetic snapshots: a 5-day clean PR hits the green-CI merge override (0.105 → merge); a 45-day security PR with dirty merge state lands at 0.475 → cherry-pick. Math, weights, and override logic behave per spec — the absolute number on the security case is lower than the spec's 0.744 example, which is just fixture difference, not a scorer issue.

## Test plan

- [ ] Copy `tools/pr-necromancer/*` into `canstralian/bounty-ops-mcp` (root + `.github/workflows/`)
- [ ] Run `workflow_dispatch` with `dry_run=true` against a known stale PR, confirm report JSON + summary table
- [ ] Run with `execute=true` against one PR, confirm comment + correct disposition action (close / tag)
- [ ] Let the Sunday 23:00 UTC cron fire once and verify the artifact uploads

https://claude.ai/code/session_01ChMtt4Hb18dBenvs9ktuXo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChMtt4Hb18dBenvs9ktuXo)_